### PR TITLE
Support to use Environment value in configuraion

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -83,6 +83,20 @@ later, so we don't recommend to have duplicated config file key in multiple file
 
   include: gohan.d
 
+Environment Value
+--------------------
+
+You can use Environemnt value in the configuraion.
+
+.. code-block:: yaml
+
+  address: {{ .GOHAN_IP}}:{{ .GOHAN_PORT}}
+
+
+Note you need to use {{ and }}, and you need to put . before
+your env key.
+We are using golang text template package, so please take a
+look more at https://golang.org/pkg/text/template/
 
 Database
 --------------------

--- a/util/config.go
+++ b/util/config.go
@@ -18,6 +18,7 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 //Config stores configuration paramters for api server
@@ -38,10 +39,26 @@ func GetConfig() *Config {
 	return gohanConfig
 }
 
+//GetEnvMap reads environemnt vars and return key value
+func GetEnvMap() map[string]string {
+	envStrings := os.Environ()
+	envMap := map[string]string{}
+	for _, envKeyValue := range envStrings {
+		keyValue := strings.Split(envKeyValue, "=")
+		if len(keyValue) == 2 {
+			key := keyValue[0]
+			value := keyValue[1]
+			envMap[key] = value
+		}
+	}
+	return envMap
+}
+
 //ReadConfig reads data from config file
 //Config file can be yaml or json file
 func (config *Config) ReadConfig(path string) error {
-	data, err := LoadFile(path)
+	envMap := GetEnvMap()
+	data, err := LoadTemplate(path, envMap)
 	//(TODO) nati: verification for config data using json schema
 	if err != nil {
 		return err

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -16,22 +16,52 @@
 package util
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"os"
 )
 
-func TestConfig(t *testing.T) {
-	RegisterTestingT(t)
-	config := GetConfig()
-	Expect(config.ReadConfig("./config_test.yaml")).To(Succeed())
-	Expect(config.GetString("unknown_param", "fail")).To(Equal("fail"))
-	Expect(config.GetString("keystone/usr_keystone", "fail")).To(Equal("fail"))
-	Expect(config.GetString("address", "fail")).To(Equal(":19090"))
-	Expect(config.GetBool("keystone/use_keystone", false)).ToNot(BeFalse())
-	Expect(config.GetString("database/type", "fail")).To(Equal("sqlite3"))
-	etcdServers := config.GetStringList("etcd", nil)
-	Expect(etcdServers).ToNot(BeNil())
-	etcdServerList := config.GetList("etcd", nil)
-	Expect(etcdServerList).ToNot(BeNil())
-}
+var _ = Describe("Config utility", func() {
+	const (
+		gohanTestValue = "GOHAN_TEST_VALUE"
+	)
+	var (
+		config *Config
+	)
+
+	BeforeEach(func() {
+		config = GetConfig()
+		os.Setenv("GOHAN_TEST_KEY", "GOHAN_TEST_VALUE")
+	})
+
+	Context("When it reads plain YAML config", func() {
+		It("Should load proper values", func() {
+			Expect(config.ReadConfig("./config_test.yaml")).To(Succeed())
+			Expect(config.GetString("unknown_param", "fail")).To(Equal("fail"))
+			Expect(config.GetString("keystone/usr_keystone", "fail")).To(Equal("fail"))
+			Expect(config.GetString("address", "fail")).To(Equal(":19090"))
+			Expect(config.GetBool("keystone/use_keystone", false)).ToNot(BeFalse())
+			Expect(config.GetString("database/type", "fail")).To(Equal("sqlite3"))
+			etcdServers := config.GetStringList("etcd", nil)
+			Expect(etcdServers).ToNot(BeNil())
+			etcdServerList := config.GetList("etcd", nil)
+			Expect(etcdServerList).ToNot(BeNil())
+		})
+	})
+
+	Context("When it reads YAML template", func() {
+		It("Should load proper values", func() {
+			Expect(config.ReadConfig("./config_test.tmpl.yaml")).To(Succeed())
+			Expect(config.GetString("unknown_param", "fail")).To(Equal("fail"))
+			Expect(config.GetString("keystone/usr_keystone", "fail")).To(Equal("fail"))
+			Expect(config.GetString("address", "fail")).To(Equal(":19090"))
+			Expect(config.GetBool("keystone/use_keystone", false)).ToNot(BeFalse())
+			Expect(config.GetString("database/type", "fail")).To(Equal("sqlite3"))
+			Expect(config.GetString("test", "")).To(Equal(gohanTestValue))
+			etcdServers := config.GetStringList("etcd", nil)
+			Expect(etcdServers).ToNot(BeNil())
+			etcdServerList := config.GetList("etcd", nil)
+			Expect(etcdServerList).ToNot(BeNil())
+		})
+	})
+})

--- a/util/config_test.tmpl.yaml
+++ b/util/config_test.tmpl.yaml
@@ -1,0 +1,6 @@
+include: config_test.d
+schema: "./tests/test_schema.yaml"
+address: ":19090"
+document_root: "./etc/"
+test: "{{.GOHAN_TEST_KEY}}"
+cors: "*"


### PR DESCRIPTION
In this commit, we support to use environment value in the configruaion
so that we can resue base configraion for each environment.

You can apply go based template for configuraion by this commit
address: {{ .GOHAN_IP}}:{{ .GOHAN_PORT}}

Implements issue: #13