### PR TITLE
Fix issue when we got 401 from etcd

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -128,6 +128,10 @@
 			"Rev": "1aedb1f9e106db5d7403222313a0504a06def5b3"
 		},
 		{
+			"ImportPath": "github.com/streamrail/concurrent-map",
+			"Rev": "d9fcb63c5922e9219f204bbe9b141f238074805e"
+		},
+		{
 			"ImportPath": "github.com/stretchr/objx",
 			"Rev": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
 		},

--- a/tests/test_create_network.sh
+++ b/tests/test_create_network.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$1" >> worker_test.log

--- a/tests/test_worker.yaml
+++ b/tests/test_worker.yaml
@@ -1,0 +1,82 @@
+#######################################################
+#  Gohan API Server example configuraion
+######################################################
+
+# Sample Configuraion for testing worker condition we get 401 from etcd
+# TODO(nati) automate this
+#
+# How to test worker
+# (1) Start gohan
+#   gohan server --config-file tests/test_worker.yaml
+# (2) Start etcd
+#   etcd
+# (3) Watch result
+#   watch wc tests/worker_test.log
+# (4) Create 10000 resources
+#   seq 1 10000 | xargs -I% gohan client network create
+# (5) Test get success  if you see 10000 lines in worker_test.log
+# (6) Restart gohan
+# (7) You should be able to see 20000 lines after some time
+
+
+# database connection configuraion
+database:
+    # yaml, json, sqlite3 and mysql supported
+    # yaml and json db is for schema development purpose
+    type: "sqlite3"
+    # connection string
+    # it is file path for yaml, json and sqlite3 backend
+    connection: "./gohan.db"
+# schema path
+    drop_on_create: true
+schemas:
+    - "../etc/schema/gohan.json"
+    - "../etc/extensions/gohan_extension.yaml"
+    - "./test_worker_extension.yaml"
+    - "../etc/example_schema.yaml"
+
+editable_schema: ./example_schema.yaml
+
+# listen address for gohan
+address: ":9091"
+tls:
+    # browsers need to add exception as long as we use self-signed certificates
+    # so lets leave it disabled for now
+    enabled: false
+    key_file: ./keys/key.pem
+    cert_file: ./keys/cert.pem
+# document root of gohan API server
+# Note: only static and schema directoriy will be served
+document_root: "."
+# list of etcd backend servers
+etcd:
+    - "http://127.0.0.1:4001"
+# keystone configuraion
+keystone:
+    use_keystone: true
+    fake: true
+    auth_url: "https://localhost:9091/v2.0"
+    user_name: "admin"
+    tenant_name: "admin"
+    password: "gohan"
+# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+cors: "*"
+
+# allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
+logging:
+    stderr:
+        enabled: true
+        level: INFO
+    file:
+        enabled: true
+        level: INFO
+        filename: ./gohan.log
+
+watch:
+    keys:
+      - config/v2.0/
+    # Watch entire key
+    events:
+      - config/v2.0/networks
+      # kick extension which meets extension path
+    worker_count: 10

--- a/tests/test_worker_extension.yaml
+++ b/tests/test_worker_extension.yaml
@@ -1,0 +1,20 @@
+extensions:
+- id: donburi
+  path: .*
+  url: https://raw.githubusercontent.com/cloudwan/gohan/master/etc/extensions/donburi.js
+- id: check
+  code_type: donburi
+  code: |
+    tasks:
+    - eval: |
+       context.resource = JSON.parse(data.body);
+    - debug: "{{.resource}}"
+    - command:
+        name: "./test_create_network.sh"
+        args:
+        - "{{ .resource.id }}"
+      register: output
+      rescue:
+        - debug: "{{ .exception }}"
+    - debug: "done {{.output}}"
+  path: "sync://config/v2.0/networks"


### PR DESCRIPTION
Closes: issue #30

Etcd can hold up to 1000 history, so we need to handle this case
correctly.
We have following issues.

(1) We should clone env for each extension run by sync
(2) sync.Watch API keep blocking even if we get 401.
(3) Stop lock per resource
  In case we have more than 1000 resources, sync process do infinite
  loop because it increases etcd index by lock.

In this commit, we fix these issues,  and we added simple integration
test configuraion file.