### PR TITLE
Update Makefile to be more useful, and fix issue in vendor manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps:
 
 format:
 	@echo "$(OK_COLOR)==> Formatting$(NO_COLOR)"
-	(go fmt ./src/...)
+	go fmt ./src/...
 
 test:
 	@echo "$(OK_COLOR)==> Testing$(NO_COLOR)"
@@ -29,8 +29,8 @@ test:
 
 lint:
 	@echo "$(OK_COLOR)==> Linting$(NO_COLOR)"
-	(golint ./src/... )
-	(go vet ./src/... )
+	golint ./src/...
+	go vet ./src/...
 
 build:
 	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ WARN_COLOR=\033[33;01m
 # You need v8worker https://github.com/ry/v8worker installed in your env
 # in order to enable v8 support on extension. then set ENABLE_V8=true
 ifeq "$(ENABLE_V8)" "true"
-	GO_BUILD=go build -tags=v8 ./...
+	GO_BUILD=gb build -tags 'v8'
 else
-	GO_BUILD=go build ./...
+	GO_BUILD=gb build
 endif
 
 
@@ -21,7 +21,7 @@ deps:
 
 format:
 	@echo "$(OK_COLOR)==> Formatting$(NO_COLOR)"
-	(cd src; go fmt ./...)
+	(go fmt ./src/...)
 
 test:
 	@echo "$(OK_COLOR)==> Testing$(NO_COLOR)"
@@ -29,8 +29,8 @@ test:
 
 lint:
 	@echo "$(OK_COLOR)==> Linting$(NO_COLOR)"
-	(cd src; golint ./... )
-	(cd src; go vet ./... )
+	(golint ./src/... )
+	(go vet ./src/... )
 
 build:
 	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -129,21 +129,15 @@
 		},
 		{
 			"importpath": "github.com/onsi/ginkgo",
-			"repository": "",
-			"revision": "",
-			"branch": ""
+			"repository": "https://github.com/onsi/ginkgo",
+			"revision": "39d2c24f8a92c88f7e7f4d8ec6c80d3cc8f5ac65",
+			"branch": "master"
 		},
 		{
 			"importpath": "github.com/onsi/gomega",
 			"repository": "https://github.com/onsi/gomega",
 			"revision": "2152b45fa28a361beba9aab0885972323a444e28",
 			"branch": "master"
-		},
-		{
-			"importpath": "github.com/onsi/gomega",
-			"repository": "",
-			"revision": "",
-			"branch": ""
 		},
 		{
 			"importpath": "github.com/op/go-logging",
@@ -203,6 +197,12 @@
 			"importpath": "github.com/robfig/cron",
 			"repository": "https://github.com/robfig/cron",
 			"revision": "e4280929dd5d1064616a07bc7912264525e845e5",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/ry/v8worker",
+			"repository": "https://github.com/ry/v8worker",
+			"revision": "c37b85265197fabd5544a39d46decd3838fc21a1",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
This updates the Makefile to not require the cd src parts, and also updates the Makefile so that the gb build is used for V8 tags as well. No longer using any of the `go build` stuff there.

Also fixes issue with vendoring which was causing issues when running `gb test` which now is also operational.