### PR TITLE
Reorder schemas by dependency on load time if it is DAG

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -356,3 +356,13 @@ func (schema *Schema) StateVersioning() bool {
 func FormatParentID(parent string) string {
 	return fmt.Sprintf("%s_id", parent)
 }
+
+func (schema *Schema) relatedSchemas() []string {
+	schemas := []string{}
+	for _, p := range schema.Properties {
+		if p.Relation != "" {
+			schemas = append(schemas, p.Relation)
+		}
+	}
+	return schemas
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -23,6 +23,29 @@ import (
 )
 
 var _ = Describe("Schema", func() {
+	Describe("Schema manager", func() {
+		It("should reorder schemas if it is DAG", func() {
+			manager := GetManager()
+			schemaPath := "../tests/test_schema_dag_dependency.yaml"
+			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
+			Expect(manager.schemaOrder).To(Equal(
+				[]string{"red_resource",
+					"blue_resource",
+					"green_resource",
+					"orange_resource"}))
+		})
+
+		It("should read schemas even if it isn't DAG", func() {
+			manager := GetManager()
+			schemaPath := "../tests/test_schema_non_dag_dependency.yaml"
+			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			ClearManager()
+		})
+	})
+
 	Describe("Formatters", func() {
 		var netSchema *Schema
 

--- a/tests/test_schema_dag_dependency.yaml
+++ b/tests/test_schema_dag_dependency.yaml
@@ -1,0 +1,92 @@
+schemas:
+- description: orange_resource
+  id: orange_resource
+  plural: orange_resources
+  parent: green_resource
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+      blue_resource_id:
+        description: blue_resource
+        permission:
+        - create
+        title: blue_resource
+        type: string
+        relation: blue_resource
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: orange_resource
+  title: orange_resource
+- description: green_resource
+  id: green_resource
+  plural: green_resources
+  parent: red_resource
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+      blue_resource_id:
+        description: blue_resource
+        permission:
+        - create
+        title: blue_resource
+        type: string
+        relation: blue_resource
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: green_resource
+  title: green_resource
+- description: blue_resource
+  id: blue_resource
+  plural: blue_resources
+  parent: red_resource
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: blue_resource
+  title: blue_resource
+- description: red_resource
+  id: red_resource
+  plural: red_resources
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: red_resource
+  title: red_resource

--- a/tests/test_schema_non_dag_dependency.yaml
+++ b/tests/test_schema_non_dag_dependency.yaml
@@ -1,0 +1,66 @@
+schemas:
+- description: red_resource
+  id: red_resource
+  plural: red_resources
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+      green_resource_id:
+        description: green_resource
+        permission:
+        - create
+        title: green_resource
+        type: string
+        relation: green_resource
+        unique: false
+    propertiesOrder:
+    - id
+    - green_resource
+    type: object
+  singular: green_resource
+  title: green_resource
+- description: blue_resource
+  id: blue_resource
+  plural: blue_resources
+  parent: red_resource
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: blue_resource
+  title: blue_resource
+- description: green_resource
+  id: green_resource
+  plural: green_resources
+  parent: blue_resource
+  prefix: /
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+    propertiesOrder:
+    - id
+    type: object
+  singular: green_resource
+  title: green_resource


### PR DESCRIPTION
In this commit, we sort schemas by dependency using Tarjan's algorithm,
so that users don't need to sort it manually.

Fixes bug: #44
Fixes bug: #45