### PR TITLE
Remove .godir as it's not being used

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,1 +1,0 @@
-github.com/cloudwan/gohan


### PR DESCRIPTION
.godir support is going to be removed from the buildpack early next year as well.