### PR TITLE
Reduce docker consumption of go.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV GOHAN_PATH $GOPATH/src/github.com/cloudwan/gohan
 
 # Install go
 ADD https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz /
-RUN tar xzvf go$GO_VERSION.linux-amd64.tar.gz
-RUN mv /go /usr/local/go
+RUN tar xzvf go$GO_VERSION.linux-amd64.tar.gz && mv /go /usr/local/go
 
 # Update apt
 RUN apt-get update


### PR DESCRIPTION
There is a bit large layer in docker repository of just moving go. This can be easier to reduce.

```
% docker history jbking/gohan
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
...
9483a3b0eb46        About an hour ago   /bin/sh -c mv /go /usr/local/go                 229.4 MB
a698a39ac63f        About an hour ago   /bin/sh -c tar xzvf go$GO_VERSION.linux-amd64   229.4 MB
...
```