### PR TITLE
FakeKeystone should return internalURL and publicURL

### DIFF
--- a/cli/client/client_test_utils.go
+++ b/cli/client/client_test_utils.go
@@ -55,6 +55,8 @@ func getAuthResponse(gohanEndpointURL string) interface{} {
 					"endpoints": []map[string]interface{}{
 						map[string]interface{}{
 							"adminURL": gohanEndpointURL,
+							"internalURL": gohanEndpointURL,
+							"publicURL": gohanEndpointURL,
 							"region":   "RegionOne",
 							"id":       "2dad48f09e2a447a9bf852bcd93548ef",
 						},

--- a/server/middleware/fake.go
+++ b/server/middleware/fake.go
@@ -76,6 +76,8 @@ var serviceCatalog = []interface{}{
 		"endpoints": []interface{}{
 			map[string]interface{}{
 				"adminURL": "http://127.0.0.1:9091",
+				"internalURL": "http://127.0.0.1:9091",
+				"publicURL": "http://127.0.0.1:9091",
 				"region":   "RegionOne",
 				"id":       "2dad48f09e2a447a9bf852bcd93548ef",
 			},


### PR DESCRIPTION
Keystone response of getting token should have internalURL and
publicURL values in serviceCatalog/endpoints, but before this commit
FakeKeystone did not support them.

TODO if someone wants: admin/internal/publicURL to be configurable