### PR TITLE
'state' and 'monitoring' etcd path should be dir

### DIFF
--- a/server/sync.go
+++ b/server/sync.go
@@ -434,11 +434,11 @@ func startStateUpdatingProcess(server *Server) {
 	stateStopChan := make(chan bool)
 
 	if _, err := server.sync.Fetch(statePrefix); err != nil {
-		server.sync.Update(statePrefix, "{}")
+		server.sync.Update(statePrefix, "")
 	}
 
 	if _, err := server.sync.Fetch(statePrefix); err == nil {
-		server.sync.Update(monitoringPrefix, "{}")
+		server.sync.Update(monitoringPrefix, "")
 	}
 
 	go func() {

--- a/sync/etcd/etcd.go
+++ b/sync/etcd/etcd.go
@@ -47,12 +47,17 @@ func NewSync(etcdServers []string) *Sync {
 
 //Update sync update sync
 func (s *Sync) Update(key, jsonString string) error {
-	_, err := s.etcdClient.Set(key, jsonString, 0)
-	if err != nil {
-		log.Error(fmt.Sprintf("failed to sync with backend %s", err))
-		return err
-	}
-	return nil
+    var err error
+    if jsonString == "" {
+        _, err = s.etcdClient.SetDir(key, 0)
+    } else {
+        _, err = s.etcdClient.Set(key, jsonString, 0)
+    }
+    if err != nil {
+        log.Error(fmt.Sprintf("failed to sync with backend %s", err))
+        return err
+    }
+    return nil
 }
 
 //Delete sync update sync


### PR DESCRIPTION
In starting state update process, gohan server tries to initialize
sync paths '/state' and '/monitoring' if those do not exist.
However, these paths are created as value in etcd, so backend
cannot set any value at '/state/some/deeper/path'. This patch
will initialize those paths as directory.

fix #154