### PR TITLE
Remove installing go vet

### DIFF
--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -4,5 +4,4 @@ go get golang.org/x/tools/cmd/goimports
 go get github.com/tools/godep
 go get github.com/golang/lint/golint
 go get github.com/coreos/etcd
-go get golang.org/x/tools/cmd/vet
 go get github.com/jteeuwen/go-bindata/go-bindata


### PR DESCRIPTION
go vet has merged to the std, so no need to install it now