### PR TITLE
Fix bug that config version in sync is always zero

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -594,7 +594,7 @@ var _ = Describe("Server package test", func() {
 			Expect(json.Unmarshal([]byte(writtenConfig.Node.Value), &configContentsRaw)).To(Succeed())
 			configContents, ok := configContentsRaw.(map[string]interface{})
 			Expect(ok).To(BeTrue())
-			Expect(configContents).To(HaveKeyWithValue("version", float64(0)))
+			Expect(configContents).To(HaveKeyWithValue("version", float64(1)))
 			var configNetworkRaw interface{}
 			Expect(json.Unmarshal([]byte(configContents["body"].(string)), &configNetworkRaw)).To(Succeed())
 			configNetwork, ok := configNetworkRaw.(map[string]interface{})

--- a/server/sync.go
+++ b/server/sync.go
@@ -189,7 +189,10 @@ func (server *Server) syncEvent(resource *schema.Resource) error {
 	path := resource.Get("path").(string)
 	path = configPrefix + path
 	body := resource.Get("body").(string)
-	version, _ := resource.Get("version").(int64)
+	version, ok := resource.Get("version").(int)
+	if !ok {
+		log.Debug("cannot cast version value in int for %s", path)
+	}
 	log.Debug("event %s", eventType)
 
 	if eventType == "create" || eventType == "update" {


### PR DESCRIPTION
Incl. test case fix because test case itself has contained wrong
assertion. Network resource contains state_versioning metadata so
version value should be 1 after creation of network resource.
fix #171