### PR TITLE
Manage versioning of monitoring updates

### DIFF
--- a/docs/source/sync.rst
+++ b/docs/source/sync.rst
@@ -117,10 +117,12 @@ the result of this monitoring under the key
 .. code-block:: javascript
 
     {
+      "version": 1,
       "monitoring": "Alice is well"
     }
 
 Gohan will read this information and update the database accordingly.
 
 Any monitoring updates made when the state version does not yet equal
+the config version or the version in the JSON data doesn't match with
 the config version will be ignored.

--- a/server/sync.go
+++ b/server/sync.go
@@ -397,9 +397,16 @@ func MonitoringUpdate(response *gohan_sync.Event, server *Server) error {
 		return nil
 	}
 	var ok bool
+	monitoringVersion, ok := response.Data["version"].(float64)
+	if !ok {
+		return fmt.Errorf("No version in monitoring information")
+	}
+	if resourceState.ConfigVersion != int64(monitoringVersion) {
+		return nil
+	}
 	resourceState.Monitoring, ok = response.Data["monitoring"].(string)
 	if !ok {
-		return fmt.Errorf("No monitoring in state information")
+		return fmt.Errorf("No monitoring in monitoring information")
 	}
 
 	environmentManager := extension.GetManager()


### PR DESCRIPTION
Add `version` field to the JSON format of monitoring update so that
Gohan can ignore updates from monitoring agents which still have old
configuration values.
This situation can happen when the monitoring agents receive requests
for stopping/starting monitoring in an async manner.