### PR TITLE
Allow empty input for custom actions

### DIFF
--- a/schema/action.go
+++ b/schema/action.go
@@ -40,7 +40,7 @@ func NewActionFromObject(id string, rawData interface{}) (Action, error) {
 	actionData, _ := rawData.(map[string]interface{})
 	method, _ := actionData["method"].(string)
 	path, _ := actionData["path"].(string)
-	inputSchema, _ := actionData["input"]
-	outputSchema, _ := actionData["output"]
-	return NewAction(id, method, path, inputSchema.(map[string]interface{}), outputSchema.(map[string]interface{})), nil
+	inputSchema, _ := actionData["input"].(map[string]interface{})
+	outputSchema, _ := actionData["output"].(map[string]interface{})
+	return NewAction(id, method, path, inputSchema, outputSchema), nil
 }

--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -700,9 +700,11 @@ func ActionResource(context middleware.Context, dataStore db.DB, identityService
 		return fmt.Errorf("No environment for schema")
 	}
 
-	err := resourceSchema.Validate(actionSchema, data)
-	if err != nil {
-		return ResourceError{err, fmt.Sprintf("Validation error: %s", err), WrongData}
+	if actionSchema != nil {
+		err := resourceSchema.Validate(actionSchema, data)
+		if err != nil {
+			return ResourceError{err, fmt.Sprintf("Validation error: %s", err), WrongData}
+		}
 	}
 
 	if err := extension.HandleEvent(context, environment, action.ID); err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -974,6 +974,13 @@ var _ = Describe("Server package test", func() {
 			}))
 		})
 
+		It("should work without input shema", func() {
+			result := testURL("GET", responderPluralURL+"/r1/dobranoc", memberTokenID, nil, http.StatusOK)
+			Expect(result).To(Equal(map[string]interface{}{
+				"output": "Dobranoc!",
+			}))
+		})
+
 		It("should be unauthorized", func() {
 			testHiAction := map[string]interface{}{
 				"name": "Heisenberg",

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -21,6 +21,14 @@ extensions:
     });
   id: test
   path: /v2.0/responder
+- code: |
+    gohan_register_handler("dobranoc", function (context) {
+        context.response_code = 200;
+        context.response = {"output": "Dobranoc!"};
+    });
+  id: test
+  path: /v2.0/responder
+
 
 networks: []
 
@@ -34,6 +42,12 @@ policies:
 - action: hello
   effect: allow
   id: member_hello
+  principal: _member_
+  resource:
+    path: /v2.0/responder.*
+- action: dobranoc
+  effect: allow
+  id: member_dobranoc
   principal: _member_
   resource:
     path: /v2.0/responder.*
@@ -371,5 +385,11 @@ schemas:
         type: object
       output:
         type: string
+    dobranoc:
+      method: GET
+      path: /:id/dobranoc
+      output:
+        type: string
+
 
 subnets: []


### PR DESCRIPTION
When you want a simple GET action without any parameters, you should be able to omit `input` field of the schema.

Btw, I could not found test for custom actions. They are missing now?