### PR TITLE
Fill default values when creating resource by gohan_db_create

### DIFF
--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -140,6 +140,17 @@ var _ = Describe("Runner", func() {
 			})
 		})
 
+		Context("When filling default values to create db data", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/default_value_schema.js"
+			})
+
+			It("Should return no errors", func() {
+				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveKeyWithValue("testDBCreatePopulateDefault", BeNil()))
+			})
+		})
+
 		Context("When loading extensions", func() {
 			BeforeEach(func() {
 				testFile = "./test_data/extension_loading.js"

--- a/extension/framework/runner/test_data/default_value_schema.js
+++ b/extension/framework/runner/test_data/default_value_schema.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+var SCHEMAS = ["./schema.yaml"];
+var PATH = "/v1.0/networks";
+
+var subnet = {
+  "id": "4e8e5957-649f-477b-9e5b-f1f75b21c03c",
+  "name": "Subnet 1",
+  "tenant_id": "9bacb3c5d39d41a79512987f338cf177"
+};
+
+function testDBCreatePopulateDefault() {
+  var result = gohan_db_create(MockTransaction(), "subnet", subnet);
+  if (!_.has(result, "ipv6_address_mode")) {
+    Fail("Failed to populate object default values using schema file.");
+  }
+}

--- a/extension/otto/gohan_db.go
+++ b/extension/otto/gohan_db.go
@@ -150,6 +150,7 @@ func init() {
 				dataMap, _ := data.(map[string]interface{})
 				manager := schema.GetManager()
 				resource, err := manager.LoadResource(schemaID, dataMap)
+                resource.PopulateDefaults()
 				if err != nil {
 					ThrowOttoException(&call, "Error during gohan_db_create: %s", err.Error())
 				}


### PR DESCRIPTION
Currently, if some properties of input data do not exist, default values
defined in schema file are not filled. In this time, mysql default values
are filled with mysql, and server error occurs with sqlite3. The big
problem here is the difference of behavior between mysql and sqlite3.

This fix enables default values defined in schema are filled in using
gohan_db_create.