### PR TITLE
Remove post_in_transaction and post events from custom actions

### DIFF
--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -131,6 +131,11 @@ update data in db without informing etcd
 
 delete data in db
 
+- gohan_db_transaction()
+
+start a new DB transaction. You are responsible for managing tranansactions created by this function. Call .Close() or .Commit() after using the return value.
+
+
 - gohan_model_list(context, schema_id, filter)
 
   Retrieve data through Gohan.

--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -623,23 +623,11 @@ Then, register extension to handle it, e.g.
 
 .. code-block:: javascript
 
-  gohan_register_handler("pre_action_reboot_in_transaction", function(context){
-    // retrieve necessary details regarding vm from db
-  });
-
   gohan_register_handler("action_reboot", function(context){
     // handle reboot in southbound
   });
 
 In order to query above action, POST to /v1.0/servers/:id/action with
-
-Available events
-
-- pre_$action
-- pre_$action_in_transaction
-- $action
-- post_$action_in_transaction
-- post_$action
 
 .. code-block:: json
 

--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -197,21 +197,33 @@ var _ = Describe("Runner", func() {
 			})
 		})
 
-		Context("When incorrectly using the Gohan HTTP mock", func() {
+		Context("When incorrectly using mock", func() {
 			BeforeEach(func() {
 				testFile = "./test_data/mock_validate.js"
 			})
 
 			It("Should return the proper errors", func() {
-				Expect(errors).To(HaveLen(4))
+				Expect(errors).To(HaveLen(3))
 				Expect(errors).To(HaveKeyWithValue(
 					"testMockExpectNotSpecified", MatchError(ContainSubstring("Expect() should be specified for each call to"))))
 				Expect(errors).To(HaveKeyWithValue(
 					"testMockReturnNotSpecified", MatchError(ContainSubstring("Return() should be specified for each call to"))))
 				Expect(errors).To(HaveKeyWithValue(
-					"testMockExpectEmpty", MatchError(ContainSubstring("Expect() should be called with at least one argument"))))
-				Expect(errors).To(HaveKeyWithValue(
 					"testMockReturnEmpty", MatchError(ContainSubstring("Return() should be called with exactly one argument"))))
+			})
+		})
+
+		Context("When mock expected calls do not occur", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/mock_calls_not_made.js"
+			})
+
+			It("Should work", func() {
+				Expect(errors).To(HaveLen(2))
+				Expect(errors).To(HaveKeyWithValue(
+					"testFirstMockCallNotMade", MatchError("Expected call to gohan_http([POST]) with return value OK, but not made")))
+				Expect(errors).To(HaveKeyWithValue(
+					"testLastMockCallNotMade", MatchError("Expected call to gohan_http([GET]) with return value OK, but not made")))
 			})
 		})
 
@@ -234,17 +246,22 @@ var _ = Describe("Runner", func() {
 			})
 		})
 
-		Context("When Gohan HTTP mock expected calls do not occur", func() {
+		Context("When correctly using the Gohan DB Transaction mock", func() {
 			BeforeEach(func() {
-				testFile = "./test_data/mock_calls_not_made.js"
+				testFile = "./test_data/gohan_db_transaction_mock.js"
 			})
 
 			It("Should work", func() {
-				Expect(errors).To(HaveLen(2))
+				Expect(errors).To(HaveLen(4))
 				Expect(errors).To(HaveKeyWithValue(
-					"testFirstMockCallNotMade", MatchError("Expected call to gohan_http([POST]) with return value OK, but not made")))
+					"testUnexpectedCall", MatchError(ContainSubstring("Unexpected call"))))
+				Expect(errors).To(HaveKeyWithValue("testSingleReturnSingleCall", BeNil()))
 				Expect(errors).To(HaveKeyWithValue(
-					"testLastMockCallNotMade", MatchError("Expected call to gohan_http([GET]) with return value OK, but not made")))
+					"testSingleReturnMultipleCalls", MatchError(ContainSubstring("Unexpected call"))))
+				Expect(errors).To(HaveKeyWithValue(
+					"testWrongArgumentsCall", MatchError(ContainSubstring("Wrong arguments"))))
+				Expect(errors).To(HaveKeyWithValue(
+					"testWrongArgumentsCall", MatchError(ContainSubstring("expected []"))))
 			})
 		})
 

--- a/extension/framework/runner/test_data/mock_validate.js
+++ b/extension/framework/runner/test_data/mock_validate.js
@@ -25,10 +25,6 @@ function testMockReturnNotSpecified() {
   gohan_http.Expect("POST");
 }
 
-function testMockExpectEmpty() {
-  gohan_http.Expect().Return("OK");
-}
-
 function testMockReturnEmpty() {
   gohan_http.Expect("POST").Return();
 }

--- a/extension/otto/gohan_db.go
+++ b/extension/otto/gohan_db.go
@@ -27,6 +27,15 @@ func init() {
 	gohanDBInit := func(env *Environment) {
 		vm := env.VM
 		builtins := map[string]interface{}{
+			"gohan_db_transaction": func(call otto.FunctionCall) otto.Value {
+				VerifyCallArguments(&call, "gohan_db_transaction", 0)
+				tx, err := env.DataStore.Begin()
+				if err != nil {
+					ThrowOttoException(&call, "failed to start a transaction")
+				}
+				value, _ := vm.ToValue(tx)
+				return value
+			},
 			"gohan_db_list": func(call otto.FunctionCall) otto.Value {
 				VerifyCallArguments(&call, "gohan_db_list", 3)
 				rawTransaction, _ := call.Argument(0).Export()

--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -707,17 +707,8 @@ func ActionResource(context middleware.Context, dataStore db.DB, identityService
 		}
 	}
 
-	if err := extension.HandleEvent(context, environment, action.ID); err != nil {
-		return err
-	}
-
-	if err := InTransaction(context, dataStore, transaction.GetIsolationLevel(resourceSchema, action.ID), func() error {
-		return extension.HandleEvent(context, environment, fmt.Sprintf("post_%s_in_transaction", action.ID))
-	}); err != nil {
-		return err
-	}
-
-	if err := extension.HandleEvent(context, environment, fmt.Sprintf("post_%s", action.ID)); err != nil {
+	err := extension.HandleEvent(context, environment, action.ID)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
There are inconsistency between the document and the actual
implementation. In the document, custom actions are described as supporting
pre, pre_in_transaction, post_in_transaction and post events.
However, the actual implementation has only post_in_transaction
and post events. In addition to that, post_in_transaction is a bit broken because the main
event (action itself) is not included in the same transaction.
This commit simply removes those events anyway and move the main event
into the transaction. We can re-implement the other events in a proper way when requested.