### PR TITLE
Add missing test JS file for gohan_db_transaction

### DIFF
--- a/extension/framework/runner/test_data/gohan_db_transaction_mock.js
+++ b/extension/framework/runner/test_data/gohan_db_transaction_mock.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+var SCHEMAS = ["./schema.yaml"];
+var PATH = "/v1.0/networks";
+
+function testUnexpectedCall() {
+  var tx = gohan_db_transaction();
+}
+
+function testSingleReturnSingleCall() {
+  var mock_transaction = "mock_transaction";
+  gohan_db_transaction.Expect().Return(mock_transaction);
+  var tx = gohan_db_transaction();
+  if (tx !== mock_transaction) {
+    Fail();
+  }
+}
+
+function testSingleReturnMultipleCalls() {
+  var mock_transaction = "mock_transaction";
+  gohan_db_transaction.Expect().Return(mock_transaction);
+  var tx = gohan_db_transaction();
+  if (tx !== mock_transaction) {
+    Fail();
+  }
+
+  var unexpected_tx = gohan_db_transaction();
+}
+
+function testWrongArgumentsCall() {
+  var mock_transaction = "mock_transaction";
+  gohan_db_transaction.Expect().Return(mock_transaction);
+  var tx = gohan_db_transaction("something extra");
+  if (tx !== mock_transaction) {
+    Fail();
+  }
+}


### PR DESCRIPTION
We are getting false pass results... will update test scripts for wrecker later.

This PR has a failure test case because of the lack of the file in this PR, but the result was SUCCESS.
https://app.wercker.com/#buildstep/572b966ae714465f2e09116d