### PR TITLE
Fix bug of initiating etcd path for monitoring

### DIFF
--- a/server/sync.go
+++ b/server/sync.go
@@ -447,7 +447,7 @@ func startStateUpdatingProcess(server *Server) {
 		server.sync.Update(statePrefix, "")
 	}
 
-	if _, err := server.sync.Fetch(statePrefix); err == nil {
+	if _, err := server.sync.Fetch(monitoringPrefix); err != nil {
 		server.sync.Update(monitoringPrefix, "")
 	}
 


### PR DESCRIPTION
/monitoring path should be initiated if this path does not exist
in starting gohan.