### PR TITLE
Fix bugs of SQL JOIN and column generation

### DIFF
--- a/extension/otto/gohan_db.go
+++ b/extension/otto/gohan_db.go
@@ -300,7 +300,6 @@ func init() {
 				if err != nil {
 					ThrowOttoException(&call, err.Error())
 				}
-
 				value, _ := vm.ToValue(results)
 				return value
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -270,7 +270,7 @@ func NewServer(configFile string) (*Server, error) {
 		m.MapTo(server.keystoneIdentity, (*middleware.IdentityService)(nil))
 		m.Use(middleware.Authentication())
 		//m.Use(Authorization())
-	}else{
+	} else {
 		m.MapTo(&middleware.NoIdentityService{}, (*middleware.IdentityService)(nil))
 		m.Map(schema.NewAuthorization("admin", "admin", "admin_token", []string{"admin"}, nil))
 	}

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -5,6 +5,7 @@ schemas:
     - "embed://etc/schema/gohan.json"
     - "../tests/test_abstract_schema.yaml"
     - "../tests/test_schema.yaml"
+    - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"
 etcd:

--- a/server/server_test_mysql_config.yaml
+++ b/server/server_test_mysql_config.yaml
@@ -6,6 +6,7 @@ schemas:
     - "../etc/schema/gohan.json"
     - "../tests/test_abstract_schema.yaml"
     - "../tests/test_schema.yaml"
+    - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"
 etcd:

--- a/tests/test_two_same_relations_schema.yaml
+++ b/tests/test_two_same_relations_schema.yaml
@@ -1,0 +1,123 @@
+schemas:
+
+- id: city
+  description: City
+  singular: city
+  plural: cities
+  title: City
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: The ID of City
+        title: ID
+        type: string
+        permission:
+        - create
+      name:
+        description: Name
+        title: Name
+        type: string
+        permission:
+        - create
+    propertiesOrder:
+    - id
+    - name
+    type: object
+
+- id: school
+  description: School
+  singular: school
+  plural: schools
+  title: School
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: The ID of School
+        title: ID
+        type: string
+        permission:
+        - create
+      name:
+        description: Name
+        title: Name
+        type: string
+        permission:
+        - create
+      city_id:
+        description: City
+        title: City
+        type: string
+        relation: city
+        relation_property: city
+        permission:
+        - create
+    propertiesOrder:
+    - id
+    - name
+    - city_id
+    type: object
+
+- id: child
+  description: Child
+  singular: child
+  plural: children
+  title: Child
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: The ID of Child
+        title: ID
+        type: string
+        permission:
+        - create
+      school_id:
+        description: School
+        title: School
+        type: string
+        relation: school
+        relation_property: school
+        permission:
+        - create
+    propertiesOrder:
+    - id
+    - school_id
+    type: object
+
+- id: parent
+  description: Parent
+  singular: parent
+  plural: parents
+  title: Parent
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: The ID of Parent
+        title: ID
+        type: string
+        permission:
+        - create
+      boy_id:
+        description: Boy
+        title: Boy
+        type: string
+        relation: child
+        relation_property: boy
+        permission:
+        - create
+      girl_id:
+        description: Girl
+        title: Girl
+        type: string
+        relation: child
+        relation_property: girl
+        permission:
+        - create
+    propertiesOrder:
+    - id
+    - boy_id
+    - girl_id
+    type: object


### PR DESCRIPTION
If some resource has two or more relation properties to the same
resource which has some other relation properties, SQL join
generation can generate ambiguous alias. To avoid this problem,
table and column name should be generalized in the recursive manner.

fixes #215