### PR TITLE
Allow dynamic sync path in schema metadata

### DIFF
--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -312,6 +312,11 @@ Metadata
 
   whether to support :ref:`state versioning <subsection-state-update>`, defaults to false.
 
+- sync_key_template (string)
+
+  configurable sync key path for schemas based on properties, for example: /v1.0/devices/{{device_id}}/virtual_machine/{{id}},
+  it must contain '{{id}}'
+
 Properties
 -------------------------------
 

--- a/etc/schema/gohan.json
+++ b/etc/schema/gohan.json
@@ -69,7 +69,14 @@
                             "update"
                         ],
                         "title": "Metadata",
-                        "type": "object"
+                        "type": "object",
+
+                        "patternProperties": {
+                            "sync_key_template": {
+                                "type": "string",
+                                "format": "sync-key-template"
+                            }
+                        }
                     },
                     "namespace": {
                         "default": "",

--- a/schema/formats.go
+++ b/schema/formats.go
@@ -34,6 +34,7 @@ type nonHyphenatedUUIDFormatChecker struct{}
 type portFormatChecker struct{}
 type yamlFormatChecker struct{}
 type textFormatChecker struct{}
+type syncKeyTemplateFormatChecker struct{}
 
 func (f macFormatChecker) IsFormat(input string) bool {
 	match, _ := regexp.MatchString(`^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$`, input)
@@ -84,6 +85,11 @@ func (f textFormatChecker) IsFormat(input string) bool {
 	return true
 }
 
+func (f syncKeyTemplateFormatChecker) IsFormat(input string) bool {
+	match, _ := regexp.MatchString(`^.*({{id}}).*$`, input)
+	return match
+}
+
 func registerGohanFormats(checkers gojsonschema.FormatCheckerChain) {
 	checkers.Add("mac", macFormatChecker{})
 	checkers.Add("cidr", cidrFormatChecker{})
@@ -95,4 +101,5 @@ func registerGohanFormats(checkers gojsonschema.FormatCheckerChain) {
 	checkers.Add("port", portFormatChecker{})
 	checkers.Add("yaml", yamlFormatChecker{})
 	checkers.Add("text", textFormatChecker{})
+	checkers.Add("sync-key-template", syncKeyTemplateFormatChecker{})
 }

--- a/tests/test_schema_metadata.yaml
+++ b/tests/test_schema_metadata.yaml
@@ -1,0 +1,66 @@
+schemas:
+- description: Metadata
+  id: metadata
+  plural: metadatas
+  metadata:
+    sync_key_template: /v1.0/metadata/{{m1}}/{{m2}}/{{m3}}
+  schema:
+    properties:
+      m1:
+        description: M1
+        title: M1
+        type: string
+        unique: false
+      m2:
+        description: M2
+        title: M2
+        type: boolean
+        unique: false
+        default: false
+      m3:
+        description: M3
+        title: M3
+        type: integer
+        unique: false
+        default: false
+    propertiesOrder:
+    - m1
+    - m2
+    - m3
+    type: object
+  singular: metadata
+  title: Metadata
+- description: MetadataFailed
+  id: metadata_failed
+  plural: metadatas_failed
+  metadata:
+    sync_key_template: /v1.0/metadata-failed/{{m1}}/{{failed}}
+  schema:
+    properties:
+      m1:
+        description: M1
+        title: M1
+        type: string
+        unique: false
+    propertiesOrder:
+    - m1
+    type: object
+  singular: metadata_failed
+  title: MetadataFailed
+- description: MetadataId
+  id: metadata_id
+  plural: metadatas_id
+  metadata:
+    sync_key_template: /v1.0/metadata-id/{{id}}/
+  schema:
+    properties:
+      id:
+        description: ID
+        title: ID
+        type: string
+        unique: true
+    propertiesOrder:
+    - id
+    type: object
+  singular: metadata_id
+  title: MetadataId


### PR DESCRIPTION
In metadata it is allowed to have additional field sync_key_template. It allows dynamic path generation based on properties, 