### PR TITLE
Fill default values when creating initial data

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -88,6 +88,7 @@ func CopyDBResources(input, output DB) error {
 			log.Info("Creating resource %s", resource.ID())
 			destResource, _ := otx.Fetch(s, resource.ID(), nil)
 			if destResource == nil {
+				resource.PopulateDefaults()
 				err := otx.Create(resource)
 				if err != nil {
 					return err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -374,7 +374,7 @@ func (schema *Schema) GenerateCustomPath(data map[string]interface{}) (path stri
 func (schema *Schema) GetResourceIdFromPath(schemaPath string) string {
 	syncKeyTemplate, ok := schema.SyncKeyTemplate()
 	if !ok {
-		return strings.TrimPrefix(schemaPath, schema.URL + "/")
+		return strings.TrimPrefix(schemaPath, schema.URL+"/")
 	}
 
 	syncKeyTemplateSplit := strings.Split(syncKeyTemplate, "/")


### PR DESCRIPTION
Just like 899503d , default values are not filled when creating
initial data. Therefore, sqlite3 occurs a SQL error for inserting
data if there are some missing properties in input data. This fix
enables creating initial data for sqlite3.