### PR TITLE
Add gohan logging built-ins

### DIFF
--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -82,9 +82,51 @@ Build in javascript functions
 
 Gohan extension supports some build-in functions.
 
-- console.log(string)
+- ``gohan_log_critical(message)``
+- ``gohan_log_error(message)``
+- ``gohan_log_warning(message)``
+- ``gohan_log_notice(message)``
+- ``gohan_log_info(message)``
+- ``gohan_log_debug(message)``
 
-Logging output
+  log ``message`` in Gohan log.
+
+  ``gohan_log_<lowercase level>(message)`` is equivalent to
+  ``gohan_log(MODULE, LOG_LEVEL.<uppercase level>, message)``.
+
+- ``gohan_log(module, log_level, message)``
+
+  log ``message`` in Gohan log (general version).
+
+  - ``module``
+    The module to be used for logging. You can use ``LOG_MODULE`` for
+    the current log module. See ``gohan_log_module_push``.
+
+  - ``log_level``
+    One of ``LOG_LEVEL.CRITICAL``, ``LOG_LEVEL.ERROR``,
+    ``LOG_LEVEL.WARNING``, ``LOG_LEVEL.NOTICE``, ``LOG_LEVEL.INFO``,
+    ``LOG_LEVEL.DEBUG``.
+
+  Example usage::
+
+    gohan_log(LOG_MODULE, DEBUG, "It works");
+
+  This will print something like the following::
+
+    17:52:40.921 gohan.extension.network.post_list_in_transaction DEBUG  It works
+
+- ``gohan_log_module_push(new_module) : <old log module>``
+  Appends ``new_module`` to the current ``LOG_MODULE``.
+
+- ``gohan_log_module_restore(old_module)``
+  Restores ``LOG_MODULE`` to ``old_module``. Example usage::
+
+    old_module = gohan_log_module_push("low_level");
+    try {
+        ...
+    } finally {
+        gohan_restore_log_module(old_module)
+    }
 
 - gohan_http(method, url, headers, data, options)
 

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -37,8 +37,10 @@ var _ = Describe("Environment manager", func() {
 	)
 
 	BeforeEach(func() {
-		env1 = otto.NewEnvironment(testDB1, &middleware.FakeIdentity{}, time.Second)
-		env2 = otto.NewEnvironment(testDB2, &middleware.FakeIdentity{}, time.Second)
+		env1 = otto.NewEnvironment("extension_test1",
+			testDB1, &middleware.FakeIdentity{}, time.Second)
+		env2 = otto.NewEnvironment("extension_test2",
+			testDB2, &middleware.FakeIdentity{}, time.Second)
 	})
 
 	JustBeforeEach(func() {

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -75,7 +75,10 @@ func (env *Environment) InitializeEnvironment() error {
 	if err != nil {
 		return fmt.Errorf("Failed to connect to database: %s", err.Error())
 	}
-	env.Environment = gohan_otto.NewEnvironment(env.dbConnection, &middleware.FakeIdentity{}, 30*time.Second)
+	envName := strings.TrimSuffix(
+		filepath.Base(env.testFileName),
+		filepath.Ext(env.testFileName))
+	env.Environment = gohan_otto.NewEnvironment(envName, env.dbConnection, &middleware.FakeIdentity{}, 30*time.Second)
 	env.SetUp()
 	env.addTestingAPI()
 

--- a/extension/otto/gohan_core.go
+++ b/extension/otto/gohan_core.go
@@ -144,6 +144,7 @@ func init() {
 
 		  for (var i = 0; i < gohan_handler[event_type].length; ++i) {
 		    try {
+		      var old_module = gohan_log_module_push(event_type);
 		      gohan_handler[event_type][i](context);
 		      //backwards compatibility
 		      if (!_.isUndefined(context.response_code)) {
@@ -156,6 +157,8 @@ func init() {
 		      } else {
 		        throw e;
 		      }
+		    } finally {
+		      gohan_log_module_restore(old_module);
 		    }
 		  }
 		}

--- a/extension/otto/gohan_db_test.go
+++ b/extension/otto/gohan_db_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cloudwan/gohan/db/pagination"
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/db/transaction/mocks"
+	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/otto"
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/server/middleware"
@@ -30,9 +31,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func newEnvironmentWithExtension(extension *schema.Extension) (env extension.Environment) {
+	timelimit := time.Duration(1) * time.Second
+	extensions := []*schema.Extension{extension}
+	env = otto.NewEnvironment("db_test",
+		testDB, &middleware.FakeIdentity{}, timelimit)
+	Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+	return
+}
+
 var _ = Describe("GohanDb", func() {
 	var (
-		timelimit     time.Duration
 		manager       *schema.Manager
 		s             *schema.Schema
 		ok            bool
@@ -44,8 +53,6 @@ var _ = Describe("GohanDb", func() {
 	var ()
 
 	BeforeEach(func() {
-		timelimit = time.Second
-
 		manager = schema.GetManager()
 		s, ok = manager.Schema("test")
 		Expect(ok).To(BeTrue())
@@ -79,9 +86,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				var pagenator *pagination.Paginator
 				var fakeTx = new(mocks.Transaction)
@@ -123,9 +128,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				pagenator := &pagination.Paginator{
 					Key:   "test_string",
@@ -171,9 +174,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				pagenator := &pagination.Paginator{
 					Key:   "test_string",
@@ -221,9 +222,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				pagenator := &pagination.Paginator{
 					Key:    "test_string",
@@ -273,9 +272,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				var fakeTx = new(mocks.Transaction)
 				fakeTx.On(
@@ -323,9 +320,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				context := map[string]interface{}{}
 				Expect(env.HandleEvent("test_event", context)).To(Succeed())
@@ -346,9 +341,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				context := map[string]interface{}{}
 				err = env.HandleEvent("test_event", context)
@@ -377,9 +370,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				var fakeTx = new(mocks.Transaction)
 				fakeTx.On(
@@ -413,9 +404,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				context := map[string]interface{}{
 					"transaction": "not_a_transaction",
@@ -444,9 +433,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				context := map[string]interface{}{
 					"transaction": new(mocks.Transaction),
@@ -474,9 +461,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				context := map[string]interface{}{
 					"transaction": new(mocks.Transaction),
@@ -504,9 +489,7 @@ var _ = Describe("GohanDb", func() {
 					"path": ".*",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := newEnvironmentWithExtension(extension)
 
 				var fakeTx = new(mocks.Transaction)
 				fakeTx.On(

--- a/extension/otto/gohan_logging.go
+++ b/extension/otto/gohan_logging.go
@@ -1,0 +1,169 @@
+// Copyright (C) 2016 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otto
+
+import (
+	"github.com/dop251/otto"
+
+	logging "github.com/op/go-logging"
+	//Import otto underscore lib
+	_ "github.com/dop251/otto/underscore"
+)
+
+const (
+	// e.g. {Log level} must be {an int}: "ERROR"
+	wrongTypeErrorMessageFormat = "%s must be %s: %v"
+)
+
+func init() {
+	gohanLoggingInit := func(env *Environment) {
+		vm := env.VM
+
+		builtins := map[string]interface{}{
+			"gohan_log": func(call otto.FunctionCall) otto.Value {
+				VerifyCallArguments(&call, "gohan_log", 3)
+
+				// TODO:
+				// Taking this as an argument is a workaround
+				// for Otto returning stale values of variables
+				// that have been changed in javascript.
+				// We can get this from LOG_MODULE javascript
+				// variable if we fix the problem.
+				module, err := GetString(call.Argument(0))
+				if err != nil {
+					ThrowOttoException(&call, "Log module: %v", err)
+				}
+				logger := logging.MustGetLogger(module)
+
+				intLevel, err := GetInt64(call.Argument(1))
+				if err != nil {
+					ThrowOttoException(&call, "Log level: %v", err)
+				}
+				level := logging.Level(intLevel)
+
+				message, err := GetString(call.Argument(2))
+				if err != nil {
+					ThrowOttoException(&call, "Message: %v", err)
+				}
+
+				logGeneral(logger, level, message)
+
+				return otto.Value{}
+			},
+		}
+		for name, object := range builtins {
+			vm.Set(name, object)
+		}
+
+		// op/go-logging/level.go has levelNames[], but it's unexported
+		logLevels := map[string]logging.Level{
+			"CRITICAL": logging.CRITICAL,
+			"ERROR":    logging.ERROR,
+			"WARNING":  logging.WARNING,
+			"NOTICE":   logging.NOTICE,
+			"INFO":     logging.INFO,
+			"DEBUG":    logging.DEBUG,
+		}
+		vm.Set("LOG_LEVEL", logLevels)
+
+		vm.Set("LOG_MODULE", "gohan.extension."+env.Name)
+
+		err := env.Load("<Gohan logging built-ins>", `
+		function gohan_log_module_push(new_module){
+		    var old_module = LOG_MODULE;
+		    LOG_MODULE += "." + new_module;
+		    return old_module;
+		}
+
+		function gohan_log_module_restore(old_module){
+		    LOG_MODULE = old_module;
+		}
+
+		function gohan_log_critical(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.CRITICAL, msg);
+		}
+
+		function gohan_log_error(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.ERROR, msg);
+		}
+
+		function gohan_log_warning(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.WARNING, msg);
+		}
+
+		function gohan_log_notice(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.NOTICE, msg);
+		}
+
+		function gohan_log_info(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.INFO, msg);
+		}
+
+		function gohan_log_debug(msg) {
+		    gohan_log(LOG_MODULE, LOG_LEVEL.DEBUG, msg);
+		}
+		`)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	RegisterInit(gohanLoggingInit)
+}
+
+// logGeneral can be replaced with logger.Log(level, format, args) when https://github.com/op/go-logging/issues/80 gets fixed.
+func logGeneral(logger *logging.Logger, level logging.Level, format string, args ...interface{}) {
+	var logAction func(format string, args ...interface{})
+	switch level {
+	case logging.CRITICAL:
+		logAction = logger.Critical
+	case logging.ERROR:
+		logAction = logger.Error
+	case logging.WARNING:
+		logAction = logger.Warning
+	case logging.NOTICE:
+		logAction = logger.Notice
+	case logging.INFO:
+		logAction = logger.Info
+	case logging.DEBUG:
+		logAction = logger.Debug
+	}
+
+	logAction(format, args...)
+}
+
+// PushJSLogModule appends newModule to log module in env, returns a function that restores the original value
+func PushJSLogModule(env *Environment, newModule string) (restore func()) {
+	newModuleInVM, _ := env.VM.ToValue(newModule)
+	oldModule := pushJSLogModule(env, newModuleInVM)
+	return func() {
+		restoreJSLogModule(env, oldModule)
+	}
+}
+
+func restoreJSLogModule(env *Environment, oldModule otto.Value) {
+	_, err := env.VM.Call("gohan_log_module_restore", nil, oldModule)
+	if err != nil {
+		log.Error("Calling gohan_log_module_restore: " + err.Error())
+	}
+}
+
+func pushJSLogModule(env *Environment, newModule otto.Value) (oldModule otto.Value) {
+	oldModule, err := env.VM.Call("gohan_log_module_push", nil, newModule)
+	if err != nil {
+		log.Error("Calling gohan_log_module_push: " + err.Error())
+	}
+	return
+}

--- a/extension/otto/otto.go
+++ b/extension/otto/otto.go
@@ -50,6 +50,7 @@ func RequireModule(name string) interface{} {
 
 //Environment javascript based environment for gohan extension
 type Environment struct {
+	Name      string
 	VM        *otto.Otto
 	DataStore db.DB
 	timelimit time.Duration
@@ -57,10 +58,11 @@ type Environment struct {
 }
 
 //NewEnvironment create new gohan extension environment based on context
-func NewEnvironment(dataStore db.DB, identity middleware.IdentityService, timelimit time.Duration) *Environment {
+func NewEnvironment(name string, dataStore db.DB, identity middleware.IdentityService, timelimit time.Duration) *Environment {
 	vm := otto.New()
 	vm.Interrupt = make(chan func(), 1)
 	env := &Environment{
+		Name:      name,
 		VM:        vm,
 		DataStore: dataStore,
 		Identity:  identity,
@@ -101,7 +103,7 @@ func (env *Environment) RegisterObject(objectID string, object interface{}) {
 	env.VM.Set(objectID, object)
 }
 
-//LoadExtensionsForPath for returns extensions for specific path
+//LoadExtensionsForPath loads extensions for specific path
 func (env *Environment) LoadExtensionsForPath(extensions []*schema.Extension, path string) error {
 	for _, extension := range extensions {
 		if extension.Match(path) {
@@ -215,7 +217,7 @@ func (env *Environment) HandleEvent(event string, context map[string]interface{}
 
 //Clone makes clone of the environment
 func (env *Environment) Clone() ext.Environment {
-	newEnv := NewEnvironment(env.DataStore, env.Identity, env.timelimit)
+	newEnv := NewEnvironment(env.Name, env.DataStore, env.Identity, env.timelimit)
 	newEnv.VM = env.VM.Copy()
 	return newEnv
 }

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -37,17 +37,22 @@ import (
 	"github.com/cloudwan/gohan/util"
 )
 
+func newEnvironment() *otto.Environment {
+	timelimit := time.Duration(1) * time.Second
+
+	return otto.NewEnvironment("otto_test",
+		testDB, &middleware.FakeIdentity{}, timelimit)
+}
+
 var _ = Describe("Otto extension manager", func() {
 	var (
 		manager            *schema.Manager
 		environmentManager *extension.Manager
-		timelimit          time.Duration
 	)
 
 	BeforeEach(func() {
 		manager = schema.GetManager()
 		environmentManager = extension.GetManager()
-		timelimit = time.Second
 	})
 
 	AfterEach(func() {
@@ -87,7 +92,7 @@ var _ = Describe("Otto extension manager", func() {
 				badExtension.URL = "bad_extension.js"
 
 				extensions := []*schema.Extension{goodExtension, badExtension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				err = env.LoadExtensionsForPath(extensions, "test_path")
 				Expect(err).To(HaveOccurred(), "Expected compilation errors.")
 
@@ -115,7 +120,7 @@ var _ = Describe("Otto extension manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -146,7 +151,7 @@ var _ = Describe("Otto extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -182,7 +187,7 @@ var _ = Describe("Otto extension manager", func() {
 				badExtension.URL = "bad_extension.js"
 
 				extensions := []*schema.Extension{goodExtension, badExtension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				err = env.LoadExtensionsForPath(extensions, "test_path")
 
 				context := map[string]interface{}{
@@ -217,7 +222,7 @@ var _ = Describe("Otto extension manager", func() {
 				goodExtension.URL = "good_extension.js"
 
 				extensions := []*schema.Extension{goodExtension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				env.LoadExtensionsForPath(extensions, "test_path")
 
 				context := map[string]interface{}{
@@ -249,7 +254,7 @@ var _ = Describe("Otto extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -274,7 +279,7 @@ var _ = Describe("Otto extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -307,7 +312,7 @@ var _ = Describe("Otto extension manager", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -350,7 +355,7 @@ var _ = Describe("Otto extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env := newEnvironment()
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
@@ -375,7 +380,7 @@ var _ = Describe("Otto extension manager", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			extensions := []*schema.Extension{extension}
-			env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+			env := newEnvironment()
 			Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 			context := map[string]interface{}{}
@@ -395,7 +400,7 @@ var _ = Describe("Otto extension manager", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			extensions := []*schema.Extension{extension}
-			env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+			env := newEnvironment()
 			Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 			context := map[string]interface{}{}
@@ -474,7 +479,7 @@ var _ = Describe("Otto extension manager", func() {
 			context["auth"] = auth
 			context["identity_service"] = &middleware.FakeIdentity{}
 
-			env = otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+			env = newEnvironment()
 			environmentManager.RegisterEnvironment(schemaID, env)
 			extensions = []*schema.Extension{}
 			for event, javascript := range events {
@@ -540,7 +545,7 @@ var _ = Describe("Otto extension manager", func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 					extensions := []*schema.Extension{extension}
-					env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+					env := newEnvironment()
 					env.LoadExtensionsForPath(extensions, "test_path")
 
 					context := map[string]interface{}{
@@ -582,7 +587,7 @@ var _ = Describe("Otto extension manager", func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 					extensions := []*schema.Extension{extension}
-					env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+					env := newEnvironment()
 					env.LoadExtensionsForPath(extensions, "test_path")
 
 					context := map[string]interface{}{
@@ -630,7 +635,7 @@ var _ = Describe("Otto extension manager", func() {
 					})
 					Expect(err).ToNot(HaveOccurred())
 					extensions := []*schema.Extension{extension}
-					env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+					env := newEnvironment()
 					env.LoadExtensionsForPath(extensions, "test_path")
 
 					context := map[string]interface{}{
@@ -1314,7 +1319,7 @@ var _ = Describe("Otto extension manager", func() {
 					readSubnetContext["auth"] = auth
 					readSubnetContext["identity_service"] = &middleware.FakeIdentity{}
 
-					subnetEnv = otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+					subnetEnv = newEnvironment()
 					environmentManager.RegisterEnvironment(curSchemaID, subnetEnv)
 					curExtensions := []*schema.Extension{}
 					for event, javascript := range subnetEvents {
@@ -1437,7 +1442,7 @@ var _ = Describe("Otto extension manager", func() {
 		channel := make(chan string)
 		Context("Given environment", func() {
 			BeforeEach(func() {
-				env = otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+				env = newEnvironment()
 				env.SetUp()
 				vm := env.VM
 				builtins := map[string]interface{}{
@@ -1520,7 +1525,7 @@ var _ = Describe("Otto extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, time.Duration(100))
+				env := otto.NewEnvironment("otto_test", testDB, &middleware.FakeIdentity{}, time.Duration(100))
 				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{

--- a/server/amqp.go
+++ b/server/amqp.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cloudwan/gohan/extension"
 
-	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
 	"github.com/streadway/amqp"
 	"github.com/twinj/uuid"
@@ -47,17 +46,15 @@ func listenAMQP(server *Server) {
 	hostname, _ := os.Hostname()
 	processID := hostname + uuid.NewV4().String()
 	config := util.GetConfig()
-	manager := schema.GetManager()
 	connection := config.GetString("amqp/connection", "amqp://guest:guest@127.0.0.1:5672/")
 	queues := config.GetStringList("amqp/queues", []string{"notifications.info", "notifications.error"})
 	events := config.GetStringList("amqp/events", []string{})
 	extensions := map[string]extension.Environment{}
 	for _, event := range events {
 		path := "amqp://" + event
-		env := server.newEnvironment()
-		err := env.LoadExtensionsForPath(manager.Extensions, path)
+		env, err := server.NewEnvironmentForPath("amqp."+event, path)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("Extensions parsing error: %v", err))
+			log.Fatal(err.Error())
 		}
 		extensions[event] = env
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -183,7 +183,6 @@ func MapRouteBySchema(server *Server, dataStore db.DB, s *schema.Schema) {
 		return
 	}
 	route := server.martini
-	manager := schema.GetManager()
 
 	singleURL := s.GetSingleURL()
 	pluralURL := s.GetPluralURL()
@@ -193,10 +192,9 @@ func MapRouteBySchema(server *Server, dataStore db.DB, s *schema.Schema) {
 	//load extension environments
 	environmentManager := extension.GetManager()
 	if _, ok := environmentManager.GetEnvironment(s.ID); !ok {
-		env := server.newEnvironment()
-		err := env.LoadExtensionsForPath(manager.Extensions, pluralURL)
+		env, err := server.NewEnvironmentForPath(s.ID, pluralURL)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("Extensions parsing error:[%s] %v", pluralURL, err))
+			log.Fatal(fmt.Sprintf("[%s] %v", pluralURL, err))
 		}
 		environmentManager.RegisterEnvironment(s.ID, env)
 	}

--- a/server/cron.go
+++ b/server/cron.go
@@ -17,16 +17,15 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/robfig/cron"
 
-	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
 )
 
 //CRON Process
 func startCRONProcess(server *Server) {
-	manager := schema.GetManager()
 	config := util.GetConfig()
 	jobList := config.GetParam("cron", nil)
 	if jobList == nil {
@@ -38,10 +37,10 @@ func startCRONProcess(server *Server) {
 		job := rawJob.(map[string]interface{})
 		path := job["path"].(string)
 		timing := job["timing"].(string)
-		env := server.newEnvironment()
-		err := env.LoadExtensionsForPath(manager.Extensions, path)
+		name := strings.TrimPrefix(path, "cron://")
+		env, err := server.NewEnvironmentForPath(name, path)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("Extensions parsing error: %v", err))
+			log.Fatal(err.Error())
 		}
 		log.Info("New job for %s / %s", path, timing)
 		c.AddFunc(timing, func() {

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -84,7 +84,8 @@ var _ = Describe("Resource manager", func() {
 		context["catalog"] = auth.Catalog()
 		context["auth"] = auth
 
-		env = otto.NewEnvironment(testDB, &middleware.FakeIdentity{}, timelimit)
+		env = otto.NewEnvironment("resource_management_test",
+			testDB, &middleware.FakeIdentity{}, timelimit)
 		extensions = []*schema.Extension{}
 		for event, javascript := range events {
 			extension, err := schema.NewExtension(map[string]interface{}{

--- a/server/snmp.go
+++ b/server/snmp.go
@@ -20,14 +20,12 @@ import (
 	"net"
 
 	"github.com/cdevr/WapSNMP"
-	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
 )
 
 //SNMP Process
 //Experimental
 func startSNMPProcess(server *Server) {
-	manager := schema.GetManager()
 	config := util.GetConfig()
 	enabled := config.GetParam("snmp", nil)
 	if enabled == nil {
@@ -36,10 +34,9 @@ func startSNMPProcess(server *Server) {
 	host := config.GetString("snmp/address", "localhost:162")
 
 	path := "snmp://"
-	env := server.newEnvironment()
-	err := env.LoadExtensionsForPath(manager.Extensions, path)
+	env, err := server.NewEnvironmentForPath("snmp", path)
 	if err != nil {
-		log.Fatal(fmt.Sprintf("Extensions parsing error: %v", err))
+		log.Fatal(err.Error())
 	}
 
 	addr, err := net.ResolveUDPAddr("udp", host)

--- a/server/sync.go
+++ b/server/sync.go
@@ -545,7 +545,6 @@ func runExtensionOnSync(server *Server, response *gohan_sync.Event, env extensio
 
 //Sync Watch Process
 func startSyncWatchProcess(server *Server) {
-	manager := schema.GetManager()
 	config := util.GetConfig()
 	watch := config.GetStringList("watch/keys", nil)
 	events := config.GetStringList("watch/events", nil)
@@ -556,10 +555,9 @@ func startSyncWatchProcess(server *Server) {
 	extensions := map[string]extension.Environment{}
 	for _, event := range events {
 		path := "sync://" + event
-		env := server.newEnvironment()
-		err := env.LoadExtensionsForPath(manager.Extensions, path)
+		env, err := server.NewEnvironmentForPath("sync."+event, path)
 		if err != nil {
-			log.Fatal(fmt.Sprintf("Extensions parsing error: %v", err))
+			log.Fatal(err.Error())
 		}
 		extensions[event] = env
 	}


### PR DESCRIPTION
Currently, the only way of logging available for javascript applications is writing directly to stderr using `console.log`.

Add built-ins that use Go logging: `gohan_log_<level>(message)`, `gohan_log(module, level, message)`, and constants for log levels, so it's possible to run something like this in javascript:

```javascript
gohan_log_debug("test")
// or:
gohan_log(LOG_MODULE, DEBUG, "test");
```

and it gets shown in Gohan logs similarly to this:
```
17:57:08.901 gohan.extension.network.post_list_in_transaction DEBUG  test
```

TODO:
- [ ] Format the rest of `docs/source/extension.rst` the way the added documentation is formatted?
