### PR TITLE
Forcibly create new transaction by MockTransaction

### DIFF
--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -530,12 +530,13 @@ following API:
 
   *  ``context`` - context passed to the event handler
 
-* ``MockTransaction() : <mock transaction>`` - return a mock transaction that
+* ``MockTransaction(is_new) : <mock transaction>`` - return a mock transaction that
   can be used with built-in Gohan methods. Each test is run using a separate
   database that is deleted after ``tearDown()``, so there is no need to
   clean up the database between tests. Multiple calls to ``MockTransaction()``
   within a single ``setUp()``, test, ``tearDown()`` routine when no call to
   ``CommitMockTransaction()`` has been made will yield the same transaction.
+  ``MockTransaction(true)`` returns forcibly new transaction.
 
 * ``CommitMockTransaction()`` - commit and close the last nonclosed
   transaction. After this call any calls to ``MockTransaction()`` return

--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -312,8 +312,9 @@ var _ = Describe("Runner", func() {
 			})
 
 			It("Should return no errors", func() {
-				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveLen(2))
 				Expect(errors).To(HaveKeyWithValue("testMockTransactions", BeNil()))
+				Expect(errors).To(HaveKeyWithValue("testMockTransactionsInOneTrigger", BeNil()))
 			})
 		})
 

--- a/extension/framework/runner/test_data/extension1.js
+++ b/extension/framework/runner/test_data/extension1.js
@@ -29,3 +29,24 @@ CustomError.prototype = new Error;
 gohan_register_handler("pre_list", function(context) {
   throw new CustomError("ExtensionError");
 });
+
+gohan_register_handler("custom_action", function (context) {
+  var tx = gohan_db_transaction();
+  var new_network = {
+    "id": context.id,
+    "name": "Net1",
+    "status": "ACTIVE"
+  };
+  gohan_db_create(tx, "network", new_network);
+  tx.Commit();
+  tx.Close();
+
+  tx = gohan_db_transaction();
+  var new_network = {
+    "id": context.id,
+    "status": "DOWN"
+  };
+  gohan_db_update(tx, "network", new_network);
+  tx.Commit();
+  tx.Close();
+});

--- a/extension/framework/runner/test_data/mock_transactions.js
+++ b/extension/framework/runner/test_data/mock_transactions.js
@@ -50,3 +50,17 @@ function testMockTransactions() {
         JSON.stringify([network1]), JSON.stringify(resources));
   }
 }
+
+function testMockTransactionsInOneTrigger() {
+  var context = {
+    "id": "net1"
+  };
+  gohan_db_transaction.Expect().Return(MockTransaction());
+  gohan_db_transaction.Expect().Return(MockTransaction(true));
+  GohanTrigger("custom_action", context);
+  var resource = gohan_db_fetch(MockTransaction(), "network", context.id, "");
+  if ("DOWN" !== resource.status) {
+    Fail("Fail to update resource status = expected %s, received %s",
+        "DOWN", resource.status);
+  }
+}

--- a/extension/framework/runner/test_data/schema.yaml
+++ b/extension/framework/runner/test_data/schema.yaml
@@ -77,6 +77,12 @@ schemas:
     - subnets
   singular: network
   title: Network
+  actions:
+    custom_action:
+      path: /:id/custom_action
+      method: POST
+      output:
+        type: object
 - description: Subnet
   id: subnet
   namespace: neutronV2


### PR DESCRIPTION
In one custom action, developers sometimes want to close transaction,
then recreate new transaction to avoid DB lock for a long time.
For example, in the workflow like fetching the DB data, http request to
backend system, then update the DB data, http request can take a
long time especially in some failure case, so developers want to close
transaction of gohan_db_fetch.

Above workflow works well, but it was difficult to write unit test.
In unit test, developers want to write as

  gohan_db_transaction.Expect().Return(MockTransaction())

In this case, at least two calls of gohan_db_transaction are expected.
So, developers want to write above statements twice. However,
MockTransaction() is evaluated in the place of writing above statement,
so new transaction is not created. Therefore, unit tests do not work
as developers expected.

This patch allows one boolean argument for MockTransaction to forcibly
create new transaction. If developers write MockTransaction(true),
new transaction is created if other transaction is not closed. Therefore,
if developers write as follows, unit tests for custom action which
closes transaction and recreate another one work as expected:

  gohan_db_transaction.Expect().Return(MockTransaction());
  gohan_db_transaction.Expect().Return(MockTransaction(true));
  GohanTrigger('some_custom_action', context);