### PR TITLE
Fixed generating sync_key_template path

### DIFF
--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Schema", func() {
 	Describe("Metadata", func() {
 		var metadataSchema *Schema
 		var metadataFailedSchema *Schema
-		var metadataIdSchema *Schema
+		var metadataIDSchema *Schema
 
 		BeforeEach(func() {
 			var exists bool
@@ -63,7 +63,7 @@ var _ = Describe("Schema", func() {
 			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
 			metadataSchema, exists = manager.Schema("metadata")
 			metadataFailedSchema, failedExists = manager.Schema("metadata_failed")
-			metadataIdSchema, idExists = manager.Schema("metadata_id")
+			metadataIDSchema, idExists = manager.Schema("metadata_id")
 			Expect(exists).To(BeTrue())
 			Expect(failedExists).To(BeTrue())
 			Expect(idExists).To(BeTrue())
@@ -101,11 +101,41 @@ var _ = Describe("Schema", func() {
 			data := map[string]interface{}{
 				"id": "1234",
 			}
-			path, err := metadataIdSchema.GenerateCustomPath(data)
+			path, err := metadataIDSchema.GenerateCustomPath(data)
 			Expect(err).To(Succeed())
 			Expect(path).To(Equal("/v1.0/metadata-id/1234/"))
-			str := metadataIdSchema.GetResourceIdFromPath(path)
+			str := metadataIDSchema.GetResourceIDFromPath(path)
 			Expect(str).To(Equal("1234"))
+		})
+
+		AfterEach(func() {
+			ClearManager()
+		})
+	})
+
+	Describe("SchemaPaths", func() {
+		var metadataIDSchema *Schema
+
+		BeforeEach(func() {
+			var idExists bool
+			manager := GetManager()
+			schemaPath := "../tests/test_schema_metadata.yaml"
+			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
+			metadataIDSchema, idExists = manager.Schema("metadata_id")
+			Expect(idExists).To(BeTrue())
+		})
+
+		It("GetSchemaByTemplatePath", func() {
+			data := map[string]interface{}{
+				"id": "1234",
+			}
+			path, err := metadataIDSchema.GenerateCustomPath(data)
+			Expect(err).To(Succeed())
+			Expect(GetSchemaByPath(path)).To(Equal(metadataIDSchema))
+		})
+
+		It("GetSchemaByUrl", func() {
+			Expect(metadataIDSchema).To(Equal(GetSchemaByURLPath("/metadatas_id")))
 		})
 
 		AfterEach(func() {

--- a/server/sync.go
+++ b/server/sync.go
@@ -237,8 +237,7 @@ func (server *Server) syncEvent(resource *schema.Resource) error {
 }
 
 func generatePath(resourcePath string, body string) string {
-	var curSchema = schema.GetSchemaByPath(resourcePath)
-
+	var curSchema = schema.GetSchemaByURLPath(resourcePath)
 	path := resourcePath
 	if _, ok := curSchema.SyncKeyTemplate(); ok {
 		var data map[string]interface{}
@@ -311,7 +310,7 @@ func StateUpdate(response *gohan_sync.Event, server *Server) error {
 		log.Debug("State update on unexpected path '%s'", schemaPath)
 		return nil
 	}
-	resourceID := curSchema.GetResourceIdFromPath(schemaPath)
+	resourceID := curSchema.GetResourceIDFromPath(schemaPath)
 
 	tx, err := dataStore.Begin()
 	if err != nil {
@@ -388,7 +387,7 @@ func MonitoringUpdate(response *gohan_sync.Event, server *Server) error {
 		log.Debug("Monitoring update on unexpected path '%s'", schemaPath)
 		return nil
 	}
-	resourceID := curSchema.GetResourceIdFromPath(schemaPath)
+	resourceID := curSchema.GetResourceIDFromPath(schemaPath)
 
 	tx, err := dataStore.Begin()
 	if err != nil {
@@ -551,7 +550,6 @@ func startSyncWatchProcess(server *Server) {
 	if watch == nil {
 		return
 	}
-
 	extensions := map[string]extension.Environment{}
 	for _, event := range events {
 		path := "sync://" + event


### PR DESCRIPTION
resource.Get("body") sometimes doesn't have all necessary fields to put them into generated path, so the data should be fetched from db.