### PR TITLE
test framework: Print only logs for failing tests

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -323,7 +323,10 @@ Run extensions tests in a gohan-server-like environment.
 
 Test files and directories can be supplied as arguments. See Gohan
 documentation for detail information about writing tests.`,
-		Action: framework.RunTests,
+		Flags: []cli.Flag{
+			cli.BoolFlag{Name: "verbose, v", Usage: "Print logs for passing tests"},
+		},
+		Action: framework.TestExtensions,
 	}
 }
 

--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -482,11 +482,16 @@ Event
 Testing javascript extensions
 -----------------------------
 
-You can test extensions using a testing tool bundled with Gohan through new
-command ``testextensions`` (or simply ``te``). Build and install Gohan, then
-run ``gohan testextensions <paths to files/directories to test>``. The
-framework will walk through files and recursively through directories, matching
-files named ``test_.*.js`` and running tests.
+You can test extensions using a testing tool bundled with Gohan with the command
+``test_extensions`` (or ``test_ex`` for short). Build and install Gohan, then
+run ``gohan test_extensions <paths to files/directories to test>``. The
+framework will walk through files and recursively through directories, running
+tests in files named ``test_*.js``.
+
+By default, the framework doesn't show logs and results for passing tests, so
+you won't see any output if all the tests pass. If you pass a
+``-v``/``--verbose`` flag, it will show these messages, and an additional ``All
+tests have passed.`` message if all the tests pass.
 
 Test file contents
 ^^^^^^^^^^^^^^^^^^

--- a/extension/framework/buflog/buflog.go
+++ b/extension/framework/buflog/buflog.go
@@ -1,0 +1,67 @@
+package buflog
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	logging "github.com/op/go-logging"
+)
+
+// LogBuffer an io.Writer that buffers data and prints it when instructed
+type LogBuffer struct {
+	*bytes.Buffer
+}
+
+var (
+	logBuffer = NewBuffer()
+
+	// DefaultLogOutput the default output for test framework logging
+	DefaultLogOutput io.Writer = os.Stderr
+)
+
+// Buf returns the global LogBuffer
+func Buf() *LogBuffer {
+	return logBuffer
+}
+
+// NewBuffer creates a new LogBuffer
+func NewBuffer() (buf *LogBuffer) {
+	return &LogBuffer{
+		new(bytes.Buffer),
+	}
+}
+
+// SetUpDefaultLogging sets up logging to the default output for the test framework
+func SetUpDefaultLogging() {
+	SetUpLogging(DefaultLogOutput)
+}
+
+// SetUpLogging sets up logging to output for the test framework
+func SetUpLogging(output io.Writer) {
+	backend := logging.NewLogBackend(output, "", 0)
+	format := logging.MustStringFormatter(
+		"%{color}%{time:15:04:05.000}: %{module} %{level} %{color:reset} %{message}")
+	backendFormatter := logging.NewBackendFormatter(backend, format)
+	leveledBackendFormatter := logging.AddModuleLevel(backendFormatter)
+	leveledBackendFormatter.SetLevel(logging.INFO, "")
+	leveledBackendFormatter.SetLevel(logging.DEBUG, "extest")
+	logging.SetBackend(leveledBackendFormatter)
+}
+
+// Activate redirects logging to the buffer
+func (buf *LogBuffer) Activate() {
+	buf.Reset()
+	SetUpLogging(buf)
+}
+
+// PrintLogs prints the buffered logs to the default output and clears the buffer
+func (buf *LogBuffer) PrintLogs() {
+	DefaultLogOutput.Write(buf.Bytes())
+	buf.Reset()
+}
+
+// Deactivate restores logging to the default output
+func (buf *LogBuffer) Deactivate() {
+	SetUpDefaultLogging()
+}

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -66,6 +66,7 @@ func NewEnvironment(testFileName string, testSource []byte) *Environment {
 // InitializeEnvironment creates new transaction for the test
 func (env *Environment) InitializeEnvironment() error {
 	var err error
+
 	_, file := filepath.Split(env.testFileName)
 	env.dbFile, err = ioutil.TempFile(os.TempDir(), file)
 	if err != nil {

--- a/extension/framework/runner/log.go
+++ b/extension/framework/runner/log.go
@@ -1,0 +1,7 @@
+package runner
+
+import (
+	"github.com/op/go-logging"
+)
+
+var log = logging.MustGetLogger("extest")

--- a/extension/framework/runner/runner.go
+++ b/extension/framework/runner/runner.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/cloudwan/gohan/extension/framework/buflog"
+
 	"github.com/dop251/otto"
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/parser"
@@ -32,15 +34,20 @@ const (
 	GeneralError = ""
 )
 
-type metaError struct {
-	error
-}
-
 // TestRunner abstracts running extension tests from a single file
 type TestRunner struct {
 	testFileName string
-	setUp        bool
-	tearDown     bool
+	printAllLogs bool
+
+	setUp    bool
+	tearDown bool
+}
+
+// TestRunnerErrors map[testFunction]error
+type TestRunnerErrors map[string]error
+
+type metaError struct {
+	error
 }
 
 var setUpPattern = regexp.MustCompile("^setUp$")
@@ -48,26 +55,23 @@ var tearDownPattern = regexp.MustCompile("^tearDown$")
 var testPattern = regexp.MustCompile("^test.*")
 
 // NewTestRunner creates a new test runner for a given test file
-func NewTestRunner(testFileName string) *TestRunner {
+func NewTestRunner(testFileName string, printAllLogs bool) *TestRunner {
 	return &TestRunner{
 		testFileName: testFileName,
+		printAllLogs: printAllLogs,
 	}
 }
 
 // Run performs extension tests from the file specified at runner's creation
-func (runner *TestRunner) Run() map[string]error {
+func (runner *TestRunner) Run() TestRunnerErrors {
 	src, err := ioutil.ReadFile(runner.testFileName)
 	if err != nil {
-		return map[string]error{
-			GeneralError: fmt.Errorf("Failed to read file '%s': %s", runner.testFileName, err.Error()),
-		}
+		return generalError(fmt.Errorf("Failed to read file '%s': %s", runner.testFileName, err.Error()))
 	}
 
 	program, err := parser.ParseFile(nil, runner.testFileName, src, 0)
 	if err != nil {
-		return map[string]error{
-			GeneralError: fmt.Errorf("Failed to parse file '%s': %s", runner.testFileName, err.Error()),
-		}
+		return generalError(fmt.Errorf("Failed to parse file '%s': %s", runner.testFileName, err.Error()))
 	}
 	tests := []string{}
 	for _, declaration := range program.DeclarationList {
@@ -88,28 +92,45 @@ func (runner *TestRunner) Run() map[string]error {
 
 	directory, _ := os.Getwd()
 	if err := os.Chdir(filepath.Dir(runner.testFileName)); err != nil {
-		return map[string]error{
-			GeneralError: fmt.Errorf("Failed to change directory to '%s': %s",
-				filepath.Dir(runner.testFileName),
-				err.Error()),
-		}
+		return generalError(fmt.Errorf("Failed to change directory to '%s': %s",
+			filepath.Dir(runner.testFileName),
+			err.Error()))
 	}
 	defer os.Chdir(directory)
 
-	errors := map[string]error{}
+	errors := TestRunnerErrors{}
 	for _, test := range tests {
 		errors[test] = runner.runTest(test, env)
+
 		if _, ok := errors[test].(metaError); ok {
-			return map[string]error{
-				GeneralError: errors[test],
-			}
+			return generalError(errors[test])
 		}
 	}
 
 	return errors
 }
 
+func generalError(err error) TestRunnerErrors {
+	return TestRunnerErrors{
+		GeneralError: err,
+	}
+}
+
 func (runner *TestRunner) runTest(testName string, env *Environment) (err error) {
+	if !runner.printAllLogs {
+		buflog.Buf().Activate()
+		defer func() {
+			if err != nil {
+				buflog.Buf().PrintLogs()
+			}
+			buflog.Buf().Deactivate()
+		}()
+	}
+
+	defer func() {
+		runner.printTestResult(testName, err)
+	}()
+
 	err = env.InitializeEnvironment()
 	if err != nil {
 		return metaError{err}
@@ -153,4 +174,14 @@ func (runner *TestRunner) runTest(testName string, env *Environment) (err error)
 		err = mockError
 	}
 	return
+}
+
+func (runner *TestRunner) printTestResult(testName string, testErr error) {
+	if testErr != nil {
+		log.Error(fmt.Sprintf("\t FAIL (%s:%s): %s",
+			runner.testFileName, testName, testErr.Error()))
+	} else {
+		log.Notice("\t PASS (%s:%s)",
+			runner.testFileName, testName)
+	}
 }

--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Runner", func() {
 	)
 
 	JustBeforeEach(func() {
-		theRunner := runner.NewTestRunner(testFile)
+		theRunner := runner.NewTestRunner(testFile, true)
 		errors = theRunner.Run()
 	})
 


### PR DESCRIPTION
- Print only logs for failing tests

    Add a command-line flag (`-v`) to print logs for all tests.
    Print test function result immediately
      (only if it fails or `-v` is specified).
- Don't make test file paths absolute
- Add an `All tests have passed.` message
- Print summary only when a test failed

    Print only failed tests in summary.
    Do the above unless `-v` is supplied.