### PR TITLE
Fix bug: gohan_db_list becomes error when filter includes boolean

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -810,9 +810,10 @@ func addFilterToQuery(s *schema.Schema, q sq.SelectBuilder, filter map[string]in
 			column = quote(key)
 		}
 
-		if property.Type == "boolean" {
-			v := make([]bool, len(value.([]string)))
-			for i, j := range value.([]string) {
+		queryValues, ok := value.([]string)
+		if ok && property.Type == "boolean" {
+			v := make([]bool, len(queryValues))
+			for i, j := range queryValues {
 				v[i], _ = strconv.ParseBool(j)
 			}
 			q = q.Where(sq.Eq{column: v})

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -538,8 +538,9 @@ var _ = Describe("Otto extension manager", func() {
 						  gohan_db_update(context.transaction,
 						    'network', {'id':'test1', 'name': 'name_updated', 'tenant_id': 'admin'});
 						  context.networks = gohan_db_list(context.transaction, 'network', {});
+						  context.networks2 = gohan_db_list(context.transaction, 'network', {'shared': false});
 						  gohan_db_delete(context.transaction, 'network', 'test1');
-						  context.networks2 = gohan_db_list(context.transaction, 'network', {});
+						  context.networks3 = gohan_db_list(context.transaction, 'network', {});
 						});`,
 						"path": ".*",
 					})
@@ -555,6 +556,7 @@ var _ = Describe("Otto extension manager", func() {
 					Expect(env.HandleEvent("test_event", context)).To(Succeed())
 					Expect(context["network"]).ToNot(BeNil())
 					Expect(context["networks"]).ToNot(BeNil())
+					Expect(context["networks2"]).ToNot(BeNil())
 				})
 			})
 

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -367,11 +367,13 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_bool":   false,
 				}
 			})
 
@@ -524,11 +526,13 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_bool":   false,
 				}
 			})
 
@@ -773,11 +777,13 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_bool":   false,
 				}
 			})
 
@@ -910,11 +916,13 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
 		})
@@ -1103,11 +1111,13 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
 		})
@@ -1341,6 +1351,7 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
 			inputSchema := map[string]interface{}{
@@ -1406,11 +1417,13 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_bool":   false,
 			}
 			listContext = middleware.Context{}
 			showContext = middleware.Context{}

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -301,6 +301,15 @@ schemas:
         title: Test string
         type: string
         unique: false
+      test_bool:
+        default: false
+        description: Test boolean
+        permission:
+        - create
+        - update
+        title: Test boolean
+        type: boolean
+        unique: false
     propertiesOrder:
     - id
     - tenant_id


### PR DESCRIPTION
If filter of gohan_db_list contains boolean value, this builtin
function becomes error. This is because filter for boolean expects
only query params. Query params can be multiple string values for
every key. This patch can expect both query parameter and builtin
uses.