### PR TITLE
add gohan_raw_http

### DIFF
--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -197,6 +197,7 @@ func (env *Environment) addTestingAPI() {
 	// function, so the following function has to be written in pure JavaScript.
 	env.VM.Run(`function GohanTrigger(event, context) { gohan_handle_event(event, context); }`)
 	env.mockFunction("gohan_http")
+	env.mockFunction("gohan_raw_http")
 	env.mockFunction("gohan_db_transaction")
 	env.mockFunction("gohan_config")
 }


### PR DESCRIPTION
gohan_raw_http works directly on Round Tripper instead of http.Client,
allowing developer to manually handle redirects and manage sessions