### PR TITLE
gohan_raw_http: string response body type

### DIFF
--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -138,6 +138,15 @@ data : post or put data
 options : dictionary of options for http client
 opaque : boolean - whether to parse URL or to treat it as raw
 
+- gohan_raw_http(method, url, headers, data)
+
+Fetch data from url. It uses GO RoundTripper instead of Client (as in gohan_http),
+which allows for more control.
+method : GET | POST | PUT | DELETE
+url : destination url
+headers : additional headers (eg. AUTH_TOKEN)
+data : request data (string)
+
 - gohan_config(key, default_value)
 
 get value from Gohan config. If key is not found, default value is returned.

--- a/extension/otto/gohan_util.go
+++ b/extension/otto/gohan_util.go
@@ -137,7 +137,7 @@ func init() {
 				if err != nil {
 					ThrowOttoException(&call, err.Error())
 				}
-				result["body"] = body
+				result["body"] = string(body)
 
 				value, _ := vm.ToValue(result)
 				return value

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -404,7 +404,7 @@ var _ = Describe("Otto extension manager", func() {
 				}
 				Expect(env.HandleEvent("test_event", context)).To(Succeed())
 				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("status_code", 200)))
-				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("body", []byte("{\"output\":\"value\"}"))))
+				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("body", "{\"output\":\"value\"}")))
 				server.Close()
 			})
 
@@ -445,7 +445,7 @@ var _ = Describe("Otto extension manager", func() {
 				}
 				Expect(env.HandleEvent("test_event", context)).To(Succeed())
 				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("status_code", 302)))
-				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("body", []byte(""))))
+				Expect(context).To(HaveKeyWithValue("response", HaveKeyWithValue("body", "")))
 				server.Close()
 			})
 		})


### PR DESCRIPTION
Type []byte is converted to array of numbers in otto, which results
in obfuscated logs, requires manual conversion to String type
in order to work with response body and is generally a bad idea.

In this commit, Gohan automatically converts arrived data to string
and adds missing documentation for gohan_raw_http.