### PR TITLE
dont override initial data

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -287,7 +287,7 @@ Useful for development purposes.`,
 				util.ExitFatal(err)
 			}
 
-			err = db.CopyDBResources(inDB, outDB)
+			err = db.CopyDBResources(inDB, outDB, true)
 			if err != nil {
 				util.ExitFatal(err)
 			}

--- a/db/db.go
+++ b/db/db.go
@@ -55,7 +55,7 @@ func ConnectDB(dbType, conn string, maxOpenConn int) (DB, error) {
 }
 
 //CopyDBResources copies resources from input database to output database
-func CopyDBResources(input, output DB) error {
+func CopyDBResources(input, output DB, overrideExisting bool) error {
 	schemaManager := schema.GetManager()
 	schemas := schemaManager.OrderedSchemas()
 	if len(schemas) == 0 {
@@ -93,7 +93,7 @@ func CopyDBResources(input, output DB) error {
 				if err != nil {
 					return err
 				}
-			} else {
+			} else if overrideExisting {
 				err := otx.Update(resource)
 				if err != nil {
 					return err

--- a/db/sql/sql_test.go
+++ b/db/sql/sql_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Sql", func() {
 		// Insert fixture data
 		fixtureDB, err := db.ConnectDB("json", "test_fixture.json", db.DefaultMaxOpenConn)
 		Expect(err).ToNot(HaveOccurred())
-		db.CopyDBResources(fixtureDB, dbc)
+		db.CopyDBResources(fixtureDB, dbc, true)
 
 		tx, err = dbc.Begin()
 		Expect(err).ToNot(HaveOccurred())

--- a/server/server.go
+++ b/server/server.go
@@ -242,7 +242,7 @@ func NewServer(configFile string) (*Server, error) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			db.CopyDBResources(inDB, server.db)
+			db.CopyDBResources(inDB, server.db, false)
 		}
 	}
 


### PR DESCRIPTION
When running in server mode, initial data read from config overrides
rows changed by operator. This may not be desired behavior when
running in server mode.

This commit allows CopyDBResources method to set overrideExisting flag.
When set, it won't force db update on existing row.
This flag is set to false when handling initial data for Server mode.