### PR TITLE
Crash on sync/snmp listener goroutine panic

### DIFF
--- a/server/amqp.go
+++ b/server/amqp.go
@@ -61,7 +61,7 @@ func listenAMQP(server *Server) {
 
 	for _, queue := range queues {
 		go func(queue string) {
-			defer util.LogPanic(log)
+			defer util.LogFatalPanic(log)
 			for server.running {
 				conn, err := amqp.Dial(connection)
 				if err != nil {

--- a/server/snmp.go
+++ b/server/snmp.go
@@ -51,7 +51,7 @@ func startSNMPProcess(server *Server) {
 
 	buf := make([]byte, 1024)
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		defer conn.Close()
 		for server.running {
 			rlen, remote, err := conn.ReadFromUDP(buf)

--- a/server/sync.go
+++ b/server/sync.go
@@ -284,7 +284,7 @@ func startSyncProcess(server *Server) {
 	pollingTicker := time.Tick(eventPollingTime)
 	committed := transactionCommitInformer()
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		recentlySynced := false
 		for server.running {
 			select {
@@ -483,7 +483,7 @@ func startStateUpdatingProcess(server *Server) {
 	}
 
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		for server.running {
 			lockKey := lockPath + "state"
 			err := server.sync.Lock(lockKey, true)
@@ -503,7 +503,7 @@ func startStateUpdatingProcess(server *Server) {
 		}
 	}()
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		for server.running {
 			response := <-stateResponseChan
 			err := StateUpdate(response, server)
@@ -516,7 +516,7 @@ func startStateUpdatingProcess(server *Server) {
 	monitoringResponseChan := make(chan *gohan_sync.Event)
 	monitoringStopChan := make(chan bool)
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		for server.running {
 			lockKey := lockPath + "monitoring"
 			err := server.sync.Lock(lockKey, true)
@@ -535,7 +535,7 @@ func startStateUpdatingProcess(server *Server) {
 		}
 	}()
 	go func() {
-		defer util.LogPanic(log)
+		defer util.LogFatalPanic(log)
 		for server.running {
 			response := <-monitoringResponseChan
 			err := MonitoringUpdate(response, server)
@@ -585,7 +585,7 @@ func startSyncWatchProcess(server *Server) {
 	stopChan := make(chan bool)
 	for _, path := range watch {
 		go func(path string) {
-			defer util.LogPanic(log)
+			defer util.LogFatalPanic(log)
 			for server.running {
 				lockKey := lockPath + "watch"
 				err := server.sync.Lock(lockKey, true)
@@ -606,6 +606,7 @@ func startSyncWatchProcess(server *Server) {
 	}
 	//main response lisnter process
 	go func() {
+		defer util.LogFatalPanic(log)
 		for server.running {
 			response := <-responseChan
 			server.queue.Add(job.NewJob(

--- a/util/util.go
+++ b/util/util.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -348,6 +349,14 @@ func MaybeInt(value interface{}) int {
 func LogPanic(log *logging.Logger) {
 	err := recover()
 	if err != nil {
-		log.Error(fmt.Sprintf("Panic %s", err))
+		log.Error(fmt.Sprintf("Panic %s: %s", err, debug.Stack()))
+	}
+}
+
+//LogFatalPanic logs panic and crashes Gohan process
+func LogFatalPanic(log *logging.Logger) {
+	err := recover()
+	if err != nil {
+		log.Fatalf("Panic %s: %s", err, debug.Stack())
 	}
 }


### PR DESCRIPTION
If sync processing goroutine crashes for any reason, we should not
just log panic and keep on going. In such case, Gohan is rendered
unusable, but it doesn't go down completely, so it's not detectable.

Another problem is that in case of failure in any goroutines mentioned
above logging only error message is not sufficient for debugging.

This commit changes above behavior so in case of listener goroutine
panic, it will log whole stacktrace and crash whole Gohan process.