### PR TITLE
Compare tenant IDs between parent and child

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -316,7 +316,7 @@ var _ = Describe("Server package test", func() {
 			delete(subnet, "network_id")
 
 			var result interface{}
-			testURL("POST", subnetPluralURL, adminTokenID, subnet, http.StatusBadRequest)
+			testURL("POST", subnetPluralURL, adminTokenID, subnet, http.StatusUnauthorized)
 			result = testURL("POST", getSubnetFullPluralURL("red"), adminTokenID, subnet, http.StatusCreated)
 
 			subnet["network_id"] = "networkred"


### PR DESCRIPTION
This is in regard to issue 229

A check has been added to functions UpdateResource
and CreateResource that compares tenant_id in parent
and child resources for equality and fails if they differ.