### PR TITLE
Configurable log levels in extension tests

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -325,6 +325,7 @@ Test files and directories can be supplied as arguments. See Gohan
 documentation for detail information about writing tests.`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "verbose, v", Usage: "Print logs for passing tests"},
+			cli.StringFlag{Name: "config-file,c", Value: "", Usage: "config file path"},
 		},
 		Action: framework.TestExtensions,
 	}


### PR DESCRIPTION
Introduces ability to use config file to set up logging levels for extension tests. Duplicate pull request closed due to my mistake.