### PR TITLE
Use SetIsolationLevel method for sync events

### DIFF
--- a/docs/source/schema.rst
+++ b/docs/source/schema.rst
@@ -649,8 +649,8 @@ Custom Isolation Level
 You can specify the transaction isolation level for api requests.
 Currently, this is only supported for mysql.
 The default setting is "read repeatable" for read operations and "serializable" for
-operations that modify the database (create, update, delete).
-The default for unspecified action is repeatble read.
+operations that modify the database (create, update, delete) and sync operations
+(state_update, monitoring_update). The default for unspecified action is repeatable read.
 
 .. code-block:: yaml
 

--- a/server/sync.go
+++ b/server/sync.go
@@ -42,6 +42,9 @@ const (
 
 	eventPollingTime  = 30 * time.Second
 	eventPollingLimit = 10000
+
+	StateUpdateEventName = "state_update"
+	MonitoringUpdateEventName = "monitoring_update"
 )
 
 var transactionCommited chan int
@@ -339,6 +342,10 @@ func StateUpdate(response *gohan_sync.Event, server *Server) error {
 		return err
 	}
 	defer tx.Close()
+	err = tx.SetIsolationLevel(transaction.GetIsolationLevel(curSchema, StateUpdateEventName))
+	if err != nil {
+		return err
+	}
 	curResource, err := tx.Fetch(curSchema, resourceID, nil)
 	if err != nil {
 		return err
@@ -416,6 +423,10 @@ func MonitoringUpdate(response *gohan_sync.Event, server *Server) error {
 		return err
 	}
 	defer tx.Close()
+	err = tx.SetIsolationLevel(transaction.GetIsolationLevel(curSchema, MonitoringUpdateEventName))
+	if err != nil {
+		return err
+	}
 	curResource, err := tx.Fetch(curSchema, resourceID, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Without it, it will use database default, which is usually set to
REPEATABLE_READ. This isolation level is prone to races.

This commit adds new event types for transaction and uses them to
retrieve default isolation level, which in this case is Serializable.