### PR TITLE
don't allow empty id during resource creation

### DIFF
--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -417,7 +417,7 @@ func CreateResource(
 		return ResourceError{err, err.Error(), Unauthorized}
 	}
 	context["resource"] = dataMap
-	if _, ok := dataMap["id"]; !ok {
+	if id, ok := dataMap["id"]; !ok || id == "" {
 		dataMap["id"] = uuid.NewV4().String()
 	}
 	context["id"] = dataMap["id"]

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudwan/gohan/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/twinj/uuid"
 )
 
 var _ = Describe("Resource manager", func() {
@@ -977,6 +978,22 @@ var _ = Describe("Resource manager", func() {
 					Expect(ok).To(BeTrue())
 					Expect(theResource).To(HaveKeyWithValue("tenant_id", adminTenantID))
 					Expect(theResource).To(HaveKey("id"))
+				})
+
+				It("Should replace empty id", func() {
+					err := resources.CreateResource(
+						context, testDB, fakeIdentity, currentSchema, map[string]interface{}{
+							"id": "",
+						})
+					Expect(err).NotTo(HaveOccurred())
+					result := context["response"].(map[string]interface{})
+					theResource, ok := result[schemaID]
+					resource := theResource.(map[string]interface{})
+					Expect(ok).To(BeTrue())
+					Expect(resource).To(HaveKeyWithValue("tenant_id", adminTenantID))
+					Expect(resource).To(HaveKey("id"))
+					_, err = uuid.Parse(resource["id"].(string))
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
Gohan WebUI sends empty string when form field is unfilled.
When it's saved to database in unchanged form, it would  cause
sync thread to attempt write to resource directory instead of file
and blocking all processing.

This commit changes resource creation behavior, so that it treats ""
(empty string) just the same as undefined for id property,
causing new UUID to be generated in it's place