### PR TITLE
nobody resource paths based on policy definitions

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -28,7 +28,7 @@ Gohan supports several types of conditions
 
 Example policy
 
-```
+``` yaml
   policies:
   - action: '*'
     effect: allow
@@ -81,7 +81,7 @@ Example policy
   if it is a dict, we check if we have a key for this value and, updated value matches it.
   Note that this is only valid for update action.
 
-```
+``` yaml
     policy:
       - action: 'read'
         condition:
@@ -126,3 +126,26 @@ Example policy
         id: member
         principal: Member
 ```
+
+## Resource paths with no authorization (nobody resource paths)
+
+With a special type of policy one can define a resource path that do not require authorization.
+In this policy only 'id', 'principal' and 'resource.path' properties are used. Policy 'principal'
+is always set to 'Nobody'.
+
+``` yaml
+policies:
+- id: no_auth_favicon
+  principal: Nobody
+  resource:
+    path: /favicon.ico
+- id: no_auth_member_resources
+  action: '*'
+  principal: Nobody
+  resource:
+    path: /v0.1/member_resources*
+```
+
+In the above example, the access to favicon is always granted and never requires an authorization.
+This feature is useful for web browsers and it is a good practice to set this policy.
+In the second policy, no-authorization access is granted to all member resources defined by a path wildcard.

--- a/examples/noauth/README.md
+++ b/examples/noauth/README.md
@@ -1,0 +1,38 @@
+'Nobody resource paths' policy
+--------------------
+
+In this example, we show how to define a list of paths that never
+require an authorization. A single path is defined as a regular
+expression (regex). In order to define a list of not autorized paths,
+add the following entry in the schema file:
+
+``` yaml
+policies:
+- id: no_auth_favicon
+  principal: Nobody
+  resource:
+    path: /favicon.ico
+- id: no_auth_member_resources
+  action: '*'
+  principal: Nobody
+  resource:
+    path: /v0.1/member_resources*
+```
+
+See 'docs/policy.md' for more information.
+
+Test script
+------------------
+
+An example script is provided in 'examples/noauth'. It can be run by invoking:
+``` bash
+./examples/noauth/curl_test.sh
+```
+
+In the example, three scenarios are tested:
+
+* a given path does not exist; the result should be 401.
+
+* a given path exists but it requires an authorization; the result should be 401.
+
+* a given path exists and it does not require authorization; the result should be 200.

--- a/examples/noauth/curl_test.sh
+++ b/examples/noauth/curl_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# 1
+echo -e "\e[35m\e[1m"
+echo "[1] test a non-existing path '/v0.1/missing'"
+echo "    expected result: (401) Unauthorized"
+echo -e "\e[0m"
+curl -v 127.0.0.1:9091/v0.1/missing
+
+# 2i
+echo -e "\e[35m\e[1m"
+echo "[2] test an existing and NOT whitelisted path '/v0.1/admin_only_resources'"
+echo "    expected result: (401) Unauthorized"
+echo -e "\e[0m"
+curl -v 127.0.0.1:9091/v0.1/admin_only_resources
+
+# 3
+echo -e "\e[35m\e[1m"
+echo "[1] testing an existing and whitelisted path '/v0.1/member_resources'"
+echo "    expected result: (200) OK"
+echo -e "\e[0m"
+curl -v 127.0.0.1:9091/v0.1/member_resources

--- a/examples/noauth/example_schema.yaml
+++ b/examples/noauth/example_schema.yaml
@@ -1,0 +1,148 @@
+extensions: []
+policies:
+- id: no_auth_favicon
+  action: '*'
+  principal: Nobody
+  resource:
+    path: /favicon.ico
+- id: no_auth_member_resources
+  action: '*'
+  principal: Nobody
+  resource:
+    path: /v0.1/member_resources*
+- action: read
+  effect: allow
+  id: member_schema
+  principal: Member
+  resource:
+    path: /v0.1/schemas*
+- action: '*'
+  condition:
+  - is_owner
+  effect: allow
+  id: member_policy
+  principal: Member
+  resource:
+    path: /v0.1/member_resources*
+    properties:
+    - id
+    - name
+    - description
+    - tenant_id
+- action: '*'
+  condition:
+  - is_owner
+  effect: allow
+  id: member_policy
+  principal: Member
+  resource:
+    path: /v0.1/member_resources*
+    properties:
+    - id
+    - name
+    - description
+    - tenant_id
+schemas:
+- description: Resource for member
+  id: member_resource
+  plural: member_resources
+  prefix: /v0.1
+  schema:
+    properties:
+      description:
+        description: Description
+        permission:
+        - create
+        - update
+        title: Description
+        type: string
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        view:
+        - detail
+      name:
+        description: Name
+        permission:
+        - create
+        - update
+        title: Name
+        type: string
+      tenant_id:
+        description: Tenant ID
+        permission:
+        - create
+        title: Tenant ID
+        type: string
+        view:
+        - detail
+      admin_property:
+        description: Admin Only property
+        permission:
+        - create
+        - update
+        title: Admin Only Property
+        type: string
+        view:
+        - list
+        - create
+        - update
+        - detail
+    propertiesOrder:
+    - id
+    - name
+    - description
+    - tenant_id
+    - admin_property
+    required: []
+    type: object
+  singular: member_resource
+  title: Member Resource
+- description: Users who has admin only can take a look this
+  id: admin_only_resource
+  plural: admin_only_resources
+  prefix: /v0.1
+  schema:
+    properties:
+      description:
+        description: Description
+        permission:
+        - create
+        - update
+        title: Description
+        type: string
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        view:
+        - detail
+      name:
+        description: Name
+        permission:
+        - create
+        - update
+        title: Name
+        type: string
+      tenant_id:
+        description: Tenant ID
+        permission:
+        - create
+        title: Tenant ID
+        type: string
+        view:
+        - detail
+    propertiesOrder:
+    - id
+    - name
+    - description
+    - tenant_id
+    required: []
+    type: object
+  singular: admin_only_resource
+  title: Admin Only Resource

--- a/examples/noauth/gohan.yaml
+++ b/examples/noauth/gohan.yaml
@@ -1,0 +1,57 @@
+#######################################################
+#  Gohan API Server example configuraion
+######################################################
+
+# database connection configuraion
+database:
+    # yaml, json, sqlite3 and mysql supported
+    # yaml and json db is for schema development purpose
+    type: "sqlite3"
+    # connection string
+    # it is file path for yaml, json and sqlite3 backend
+    connection: "./gohan.db"
+    drop_on_create: true
+# schema path
+schemas:
+    - "embed://etc/schema/gohan.json"
+    - "embed://etc/extensions/gohan_extension.yaml"
+    - "example_schema.yaml"
+
+editable_schema: ./example_schema.yaml
+
+# listen address for gohan
+address: ":9091"
+tls:
+    # browsers need to add exception as long as we use self-signed certificates
+    # so lets leave it disabled for now
+    enabled: false
+    key_file: ./key.pem
+    cert_file: ./cert.pem
+
+# keystone configuraion
+keystone:
+    use_keystone: true
+    fake: true
+    auth_url: "http://localhost:9091/v2.0"
+    user_name: "admin"
+    tenant_name: "admin"
+    password: "gohan"
+# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+cors: "*"
+
+# allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
+logging:
+    stderr:
+        enabled: true
+        level: DEBUG
+    file:
+        enabled: true
+        level: INFO
+        filename: ./gohan.log
+
+ssh:
+    key_file: ./id_rsa
+
+webui_config:
+    enabled: true
+    tls: false

--- a/schema/manager.go
+++ b/schema/manager.go
@@ -20,12 +20,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/cloudwan/gohan/util"
 )
+
+const nobodyPrincipal = "Nobody"
 
 //manager singleton schema manager
 var manager *Manager
@@ -429,4 +432,17 @@ func ClearManager() {
 //PolicyValidate API request using policy statements
 func (manager *Manager) PolicyValidate(action, path string, auth Authorization) (*Policy, *Role) {
 	return PolicyValidate(action, path, auth, manager.policies)
+}
+
+//NoAuthPaths returns a list of paths that do not require authorization
+func (manager *Manager) NobodyResourcePaths() []*regexp.Regexp {
+	nobodyResourcePaths := []*regexp.Regexp{}
+	for _, policy := range manager.policies {
+		if policy.Principal == nobodyPrincipal {
+			log.Debug("Adding nobody resource path: " + policy.Resource.Path.String())
+			nobodyResourcePaths = append(nobodyResourcePaths, policy.Resource.Path)
+		}
+	}
+
+	return nobodyResourcePaths
 }

--- a/schema/policy.go
+++ b/schema/policy.go
@@ -70,7 +70,7 @@ func (t Tenant) String() string {
 	return fmt.Sprintf("%s (%s)", t.Name.String(), t.ID.String())
 }
 
-//Policy describes policy configuraion for APIs
+//Policy describes policy configuration for APIs
 type Policy struct {
 	ID, Description, Principal, Action, Effect string
 	Condition                                  []interface{}

--- a/server/server.go
+++ b/server/server.go
@@ -227,6 +227,7 @@ func NewServer(configFile string) (*Server, error) {
 			return nil, fmt.Errorf("invalid schema: %s", err)
 		}
 	}
+
 	if !config.GetBool("database/no_init", false) {
 		server.initDB()
 	}
@@ -245,6 +246,8 @@ func NewServer(configFile string) (*Server, error) {
 			db.CopyDBResources(inDB, server.db, false)
 		}
 	}
+
+	m.Map(middleware.NewNobodyResourceService(manager.NobodyResourcePaths()))
 
 	if config.GetBool("keystone/use_keystone", false) {
 		//TODO remove this


### PR DESCRIPTION
A new implementation for resource path whitelists. This one is based on a policy configuration defined in schema file. When a whitelisted resource is accessed it is seen as being read by nobody user but does not require authorization.