### PR TITLE
Select single extension test cases using command line

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -325,7 +325,8 @@ Test files and directories can be supplied as arguments. See Gohan
 documentation for detail information about writing tests.`,
 		Flags: []cli.Flag{
 			cli.BoolFlag{Name: "verbose, v", Usage: "Print logs for passing tests"},
-			cli.StringFlag{Name: "config-file,c", Value: "", Usage: "config file path"},
+			cli.StringFlag{Name: "config-file,c", Value: "", Usage: "Config file path"},
+			cli.StringFlag{Name: "run-test,r", Value: "", Usage: "Run only tests matching specified regex"},
 		},
 		Action: framework.TestExtensions,
 	}

--- a/extension/framework/framework.go
+++ b/extension/framework/framework.go
@@ -56,15 +56,15 @@ func TestExtensions(c *cli.Context) {
 	testFiles := getTestFiles(c.Args())
 
 	//logging from config is a limited printAllLogs option
-	returnCode := RunTests(testFiles, c.Bool("verbose") || config != nil)
+	returnCode := RunTests(testFiles, c.Bool("verbose") || config != nil, c.String("run-test"))
 	os.Exit(returnCode)
 }
 
 // RunTests runs extension tests for CLI
-func RunTests(testFiles []string, printAllLogs bool) (returnCode int) {
+func RunTests(testFiles []string, printAllLogs bool, testFilter string) (returnCode int) {
 	errors := map[string]map[string]error{}
 	for _, testFile := range testFiles {
-		testRunner := runner.NewTestRunner(testFile, printAllLogs)
+		testRunner := runner.NewTestRunner(testFile, printAllLogs, testFilter)
 		errors[testFile] = testRunner.Run()
 		if err, ok := errors[testFile][runner.GeneralError]; ok {
 			log.Error(fmt.Sprintf("\t ERROR (%s): %v", testFile, err))

--- a/extension/framework/runner/runner.go
+++ b/extension/framework/runner/runner.go
@@ -38,6 +38,7 @@ const (
 type TestRunner struct {
 	testFileName string
 	printAllLogs bool
+	testFilter   *regexp.Regexp
 
 	setUp    bool
 	tearDown bool
@@ -55,10 +56,11 @@ var tearDownPattern = regexp.MustCompile("^tearDown$")
 var testPattern = regexp.MustCompile("^test.*")
 
 // NewTestRunner creates a new test runner for a given test file
-func NewTestRunner(testFileName string, printAllLogs bool) *TestRunner {
+func NewTestRunner(testFileName string, printAllLogs bool, testFilter string) *TestRunner {
 	return &TestRunner{
 		testFileName: testFileName,
 		printAllLogs: printAllLogs,
+		testFilter: regexp.MustCompile(testFilter),
 	}
 }
 
@@ -82,7 +84,7 @@ func (runner *TestRunner) Run() TestRunnerErrors {
 				runner.setUp = true
 			case tearDownPattern.MatchString(name):
 				runner.tearDown = true
-			case testPattern.MatchString(name):
+			case testPattern.MatchString(name) && runner.testFilter.MatchString(name):
 				tests = append(tests, name)
 			}
 		}

--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -29,13 +29,18 @@ var _ = Describe("Runner", func() {
 	)
 
 	var (
-		testFile string
-		errors   map[string]error
+		testFile   string
+		testFilter string
+		errors     map[string]error
 	)
 
 	JustBeforeEach(func() {
-		theRunner := runner.NewTestRunner(testFile, true)
+		theRunner := runner.NewTestRunner(testFile, true, testFilter)
 		errors = theRunner.Run()
+	})
+
+	AfterEach(func() {
+		testFilter = ""
 	})
 
 	Describe("With incorrect files", func() {
@@ -160,6 +165,19 @@ var _ = Describe("Runner", func() {
 				Expect(errors).To(HaveLen(2))
 				Expect(errors).To(HaveKeyWithValue("testExtension1Loaded", BeNil()))
 				Expect(errors).To(HaveKeyWithValue("testExtension2NotLoaded", BeNil()))
+			})
+		})
+
+		Context("When using filter", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/extension_loading.js"
+				testFilter = ".*1.*"
+			})
+
+			It("Should skip non-matching tests", func() {
+				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveKeyWithValue("testExtension1Loaded", BeNil()))
+				Expect(errors).NotTo(HaveKey("testExtension2NotLoaded"))
 			})
 		})
 


### PR DESCRIPTION
I found this change useful when debugging: I could run only the one particular test case that's failing, or a subset of tests. Example command line: 
`gohan test_ex -r testSomeSingleTestCase path/to/test_file.js`
`gohan test_ex -r test.*Foo.* path/to/test_file.js`