### PR TITLE
OpenAPI generator:

### DIFF
--- a/etc/templates/openapi.tmpl
+++ b/etc/templates/openapi.tmpl
@@ -208,12 +208,19 @@
 {% endif %}{% endfor %}
     },
     "definitions": { {% for schema in schemas %}{% if schema.Metadata.type != "metaschema" %}
+        {% with jsonSchema=schema.JSONSchema | swagger: "        " %}
+        {% if jsonSchema != "null"  %}
         "{{ schema.ID }}" :
-        {{ schema.JSONSchema | swagger: "        " }},
+        {{ jsonSchema }}, {% endif %} {% endwith %}
+        {% with jsonSchemaInput=schema.JSONSchemaOnCreate | swagger: "        " %}
+        {% if jsonSchemaInput != "null" %}
         "{{ schema.ID }}Input" :
-        {{ schema.JSONSchemaOnCreate |  swagger: "        " }},
+        {{ jsonSchemaInput }}, {% endif %}{% endwith %}
+        {% with jsonSchemaUpdate=schema.JSONSchemaOnUpdate | swagger: "        " %}
+        {% if jsonSchemaUpdate != "null"  %}
         "{{ schema.ID }}Update" :
-        {{ schema.JSONSchemaOnUpdate | swagger : "        "}},{% endif %}{% endfor %}
+        {{ jsonSchemaUpdate }}, {% endif %}{% endwith %}
+        {% endif %}{% endfor %}
         "errorModel": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
OpenApi API generated with example schemas (for example keystone) wasn't valid on http://editor.swagger.io/

Current implementation remove extended properties only on first and second depth of property tree. Proposed version iterate recursively over whole tree and removes them on every level.
It also fixes default value of enum type fields and remove empty 'required' fields.