### PR TITLE
add support for loading schema include files

### DIFF
--- a/extension/framework/runner/runner_test.go
+++ b/extension/framework/runner/runner_test.go
@@ -24,8 +24,9 @@ import (
 
 var _ = Describe("Runner", func() {
 	const (
-		schemasVar = "SCHEMAS"
-		pathVar    = "PATH"
+		schemaIncludesVar = "SCHEMA_INCLUDES"
+		schemasVar        = "SCHEMAS"
+		pathVar           = "PATH"
 	)
 
 	var (
@@ -98,6 +99,40 @@ var _ = Describe("Runner", func() {
 				Expect(errors).To(HaveKeyWithValue(runner.GeneralError, MatchError(ContainSubstring("no such file"))))
 			})
 		})
+
+		Context("When the test schema include is not specified", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/schema_include_not_specified.js"
+			})
+
+			It("Should return the proper errors", func() {
+				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveKeyWithValue(runner.GeneralError, MatchError(ContainSubstring(schemaIncludesVar))))
+			})
+		})
+
+		Context("When the test schema include is not a string", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/schema_include_not_a_string.js"
+			})
+
+			It("Should return the proper errors", func() {
+				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveKeyWithValue(runner.GeneralError, MatchError(ContainSubstring(schemaIncludesVar))))
+			})
+		})
+
+		Context("When the test schema include does not exist", func() {
+			BeforeEach(func() {
+				testFile = "./test_data/nonexisting_schema_include.js"
+			})
+
+			It("Should return the proper errors", func() {
+				Expect(errors).To(HaveLen(1))
+				Expect(errors).To(HaveKeyWithValue(runner.GeneralError, MatchError(ContainSubstring("no such file"))))
+			})
+		})
+
 
 		Context("When the test path is not specified", func() {
 			BeforeEach(func() {

--- a/extension/framework/runner/test_data/compilation_error.js
+++ b/extension/framework/runner/test_data/compilation_error.js
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 
+// Intentionally, the following code does not compile
 function xyz() {
-

--- a/extension/framework/runner/test_data/default_value_schema.js
+++ b/extension/framework/runner/test_data/default_value_schema.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/extension_error.js
+++ b/extension/framework/runner/test_data/extension_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/extension_loading.js
+++ b/extension/framework/runner/test_data/extension_loading.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/fail.js
+++ b/extension/framework/runner/test_data/fail.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/fail_error.js
+++ b/extension/framework/runner/test_data/fail_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/gohan_builtins.js
+++ b/extension/framework/runner/test_data/gohan_builtins.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/gohan_config_mock.js
+++ b/extension/framework/runner/test_data/gohan_config_mock.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/gohan_db_transaction_mock.js
+++ b/extension/framework/runner/test_data/gohan_db_transaction_mock.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/gohan_http_mock.js
+++ b/extension/framework/runner/test_data/gohan_http_mock.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/gohan_trigger.js
+++ b/extension/framework/runner/test_data/gohan_trigger.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/mock_calls_not_made.js
+++ b/extension/framework/runner/test_data/mock_calls_not_made.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/mock_transactions.js
+++ b/extension/framework/runner/test_data/mock_transactions.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/mock_validate.js
+++ b/extension/framework/runner/test_data/mock_validate.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/multiple_schemas.js
+++ b/extension/framework/runner/test_data/multiple_schemas.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml", "./other_schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/nonexisting_schema_include.js
+++ b/extension/framework/runner/test_data/nonexisting_schema_include.js
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var SCHEMA_INCLUDES = [];
-var SCHEMAS = ["./nonexisting_schema.yaml"];
+var SCHEMA_INCLUDES = ["./nonexisting_schema_include.lst"];
+var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 
 function testSomething() {}

--- a/extension/framework/runner/test_data/path_not_a_string.js
+++ b/extension/framework/runner/test_data/path_not_a_string.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = {};
 

--- a/extension/framework/runner/test_data/path_not_specified.js
+++ b/extension/framework/runner/test_data/path_not_specified.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 
 function testSomething() {}

--- a/extension/framework/runner/test_data/runtime_error.js
+++ b/extension/framework/runner/test_data/runtime_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/schema_include_not_a_string.js
+++ b/extension/framework/runner/test_data/schema_include_not_a_string.js
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var SCHEMA_INCLUDES = [];
-var SCHEMAS = ["./nonexisting_schema.yaml"];
+var SCHEMA_INCLUDES = 15;
+var SCHEMAS = [];
 var PATH = "/v1.0/networks";
 
 function testSomething() {}

--- a/extension/framework/runner/test_data/schema_include_not_specified.js
+++ b/extension/framework/runner/test_data/schema_include_not_specified.js
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var SCHEMA_INCLUDES = [];
-var SCHEMAS = ["./nonexisting_schema.yaml"];
+/* Intentionally not defined: var SCHEMA_INCLUDES = [];*/
+var SCHEMAS = [];
 var PATH = "/v1.0/networks";
 
 function testSomething() {}

--- a/extension/framework/runner/test_data/schema_not_a_string.js
+++ b/extension/framework/runner/test_data/schema_not_a_string.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = 15;
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/schema_not_specified.js
+++ b/extension/framework/runner/test_data/schema_not_specified.js
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
+/* Intentionally, not defined: var SCHEMAS = [];*/
 var PATH = "/v1.0/networks";
 
 function testSomething() {}

--- a/extension/framework/runner/test_data/set_up.js
+++ b/extension/framework/runner/test_data/set_up.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/set_up_error.js
+++ b/extension/framework/runner/test_data/set_up_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/tear_down.js
+++ b/extension/framework/runner/test_data/tear_down.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/tear_down_error.js
+++ b/extension/framework/runner/test_data/tear_down_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/framework/runner/test_data/tear_down_error_after_error.js
+++ b/extension/framework/runner/test_data/tear_down_error_after_error.js
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+var SCHEMA_INCLUDES = [];
 var SCHEMAS = ["./schema.yaml"];
 var PATH = "/v1.0/networks";
 

--- a/extension/otto/otto.go
+++ b/extension/otto/otto.go
@@ -337,12 +337,24 @@ func GetList(value otto.Value) ([]interface{}, error) {
 
 //GetStringList gets []string  from otto value
 func GetStringList(value otto.Value) ([]string, error) {
-	rawSlice, _ := value.Export()
-	rawResult, ok := rawSlice.([]string)
-	if !ok {
-		return make([]string, 0), fmt.Errorf(wrongArgumentType, rawSlice, "array of strings")
+	var ok bool
+	var rawSlice []interface{}
+	var stringSlice []string
+
+	rawData, _ := value.Export()
+	rawSlice, ok = rawData.([]interface{})
+
+	if ok && len(rawSlice) == 0 {
+		return []string{}, nil
 	}
-	return rawResult, nil
+
+	stringSlice, ok = rawData.([]string)
+
+	if !ok {
+		return make([]string, 0), fmt.Errorf(wrongArgumentType, rawData, "array of strings")
+	}
+
+	return stringSlice, nil
 }
 
 //GetInt64 gets int64 from otto value


### PR DESCRIPTION
With this code one can use 'schema include files' containing a list of schemas to load in a test suite. It helps to manage test suites which share a common list of schemas.