### PR TITLE
Optimize getting column list

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -299,7 +299,7 @@ func (db *DB) genTableCols(s *schema.Schema, cascade bool, exclude []string) ([]
 //AlterTableDef generates alter table sql
 func (db *DB) AlterTableDef(s *schema.Schema, cascade bool) (string, error) {
 	var existing []string
-	rows, err := db.DB.Query(fmt.Sprintf("select * from `%s`;", s.GetDbTableName()))
+	rows, err := db.DB.Query(fmt.Sprintf("select * from `%s` limit 1;", s.GetDbTableName()))
 	if err == nil {
 		defer rows.Close()
 		existing, err = rows.Columns()


### PR DESCRIPTION
We don't need to make full scan to acquire column list, 1 row is enough.