### PR TITLE
Add sync_plain and sync_property

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -145,7 +145,17 @@ We don't sync this resource for sync backend when this option is true.
 - sync_key_template (string)
 
   configurable sync key path for schemas based on properties, for example: /v1.0/devices/{{device_id}}/virtual_machine/{{id}},
-  it must contain '{{id}}'
+
+- sync_plain (boolean)
+
+  Write plain data, which is not JSON marshaled in the Gohan format, to the sync backend if true.
+  By default, which is false, Gohan writes sync data in JSON with its own format. The format has `body` and `version` properties, then the value of the resource, which is also JSON object, is stored in the `body` property with escaping (e.g. `{"body": "{\"id\":1,\"property\":\"value\"}", "version": 1}`).
+  However, this format is not always supported by your worker. Therefore you sometimes want Gohan to write sync data in a simpler way. This option allow you to get the body JSON data without encapsulation by Gohan (e.g. `{"id":1,"property":"value"}`).
+  Note that when you use this option with `sync_property`, you can get the value of a specified property. For instance, when you provide `property` to `sync_property`, you will get `value` for the result. In this case, when the type of the value is `string`, Gohan doesn't marshal the value into a JSON string, which means you don't get `"value"` here. When the value is an array or an object, you will get a JSON marshalled string.
+
+- sync_property (string)
+
+  Write only the value of the specified property to the sync backend.
 
 ## Properties
 

--- a/etc/schema/gohan.json
+++ b/etc/schema/gohan.json
@@ -69,14 +69,7 @@
                             "update"
                         ],
                         "title": "Metadata",
-                        "type": "object",
-
-                        "patternProperties": {
-                            "sync_key_template": {
-                                "type": "string",
-                                "format": "sync-key-template"
-                            }
-                        }
+                        "type": "object"
                     },
                     "namespace": {
                         "default": "",
@@ -648,6 +641,22 @@
                         "title": "Event body",
                         "type": "object"
                     },
+                    "sync_plain": {
+                        "description": "sync_plain",
+                        "permission": [
+                            "create"
+                        ],
+                        "title": "Sync without Gohan JSON marshaling",
+                        "type": "boolean"
+                    },
+                    "sync_property": {
+                        "description": "sync_property",
+                        "permission": [
+                            "create"
+                        ],
+                        "title": "Property name to sync",
+                        "type": "string"
+                    },
                     "version": {
                         "description": "The version of the config this event created",
                         "permission": [
@@ -699,6 +708,8 @@
                 },
                 "propertiesOrder": [
                     "id",
+                    "sync_plain",
+                    "sync_property",
                     "type",
                     "path",
                     "timestamp",

--- a/schema/formats.go
+++ b/schema/formats.go
@@ -34,7 +34,6 @@ type nonHyphenatedUUIDFormatChecker struct{}
 type portFormatChecker struct{}
 type yamlFormatChecker struct{}
 type textFormatChecker struct{}
-type syncKeyTemplateFormatChecker struct{}
 
 func (f macFormatChecker) IsFormat(input string) bool {
 	match, _ := regexp.MatchString(`^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$`, input)
@@ -85,11 +84,6 @@ func (f textFormatChecker) IsFormat(input string) bool {
 	return true
 }
 
-func (f syncKeyTemplateFormatChecker) IsFormat(input string) bool {
-	match, _ := regexp.MatchString(`^.*({{id}}).*$`, input)
-	return match
-}
-
 func registerGohanFormats(checkers gojsonschema.FormatCheckerChain) {
 	checkers.Add("mac", macFormatChecker{})
 	checkers.Add("cidr", cidrFormatChecker{})
@@ -101,5 +95,4 @@ func registerGohanFormats(checkers gojsonschema.FormatCheckerChain) {
 	checkers.Add("port", portFormatChecker{})
 	checkers.Add("yaml", yamlFormatChecker{})
 	checkers.Add("text", textFormatChecker{})
-	checkers.Add("sync-key-template", syncKeyTemplateFormatChecker{})
 }

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -5,6 +5,7 @@ schemas:
     - "embed://etc/schema/gohan.json"
     - "../tests/test_abstract_schema.yaml"
     - "../tests/test_schema.yaml"
+    - "../tests/test_schema_sync.yaml"
     - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"

--- a/server/server_test_mysql_config.yaml
+++ b/server/server_test_mysql_config.yaml
@@ -6,6 +6,7 @@ schemas:
     - "../etc/schema/gohan.json"
     - "../tests/test_abstract_schema.yaml"
     - "../tests/test_schema.yaml"
+    - "../tests/test_schema_sync.yaml"
     - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"

--- a/server/sync_watch.go
+++ b/server/sync_watch.go
@@ -84,8 +84,6 @@ func startSyncWatchProcess(server *Server) {
 					defer util.LogPanic(log)
 					for _, event := range events {
 						//match extensions
-						fmt.Println(response.Key)
-						fmt.Println("/" + event)
 						if strings.HasPrefix(response.Key, "/"+event) {
 							env := extensions[event]
 							runExtensionOnSync(server, response, env.Clone())

--- a/tests/test_schema_sync.yaml
+++ b/tests/test_schema_sync.yaml
@@ -1,0 +1,85 @@
+schemas:
+  - id: "with_sync_property"
+    metadata:
+      state_versioning: true
+      sync_property: "p0"
+    title: "with_sync_property"
+    description: "with_sync_property"
+    singular: "with_sync_property"
+    plural: "with_sync_properties"
+    prefix: "/v2.0"
+    schema:
+      properties:
+        id:
+          format: "uuid"
+          permission:
+            - "create"
+          title: "ID"
+          description: "ID"
+          type: "string"
+          unique: false
+        p0:
+          permission:
+            - "create"
+            - "update"
+          title: "property 0"
+          description: "property 0"
+          type: "string"
+          unique: false
+
+  - id: "with_sync_plain"
+    metadata:
+      state_versioning: true
+      sync_plain: true
+    title: "with_sync_plain"
+    description: "with_sync_plain"
+    singular: "with_sync_plain"
+    plural: "with_sync_plains"
+    prefix: "/v2.0"
+    schema:
+      properties:
+        id:
+          format: "uuid"
+          permission:
+            - "create"
+          title: "ID"
+          description: "ID"
+          type: "string"
+          unique: false
+        p0:
+          permission:
+            - "create"
+            - "update"
+          title: "property 0"
+          description: "property 0"
+          type: "string"
+          unique: false
+
+  - id: "with_sync_plain_string"
+    metadata:
+      state_versioning: true
+      sync_plain: true
+      sync_property: "p0"
+    title: "with_sync_plain"
+    description: "with_sync_plain"
+    singular: "with_sync_plain"
+    plural: "with_sync_plains"
+    prefix: "/v2.0"
+    schema:
+      properties:
+        id:
+          format: "uuid"
+          permission:
+            - "create"
+          title: "ID"
+          description: "ID"
+          type: "string"
+          unique: false
+        p0:
+          permission:
+            - "create"
+            - "update"
+          title: "property 0"
+          description: "property 0"
+          type: "string"
+          unique: false


### PR DESCRIPTION
New metadata for schemas:

`sync_plain (boolean)`

Write plain data, which is not JSON marshaled, to the sync backend if true.

`sync_property (string)`

Write only the value of the specified property to the sync backend.

These options are useful when a listener on etcd, which comes from a different projects, doesn't support the format of Gohan sync payload.

Also removing format validation on sync_key_template, because requiring always `{{id}}` in templates decreases flexibility. (Gohan should support composite unique btw)