### PR TITLE
Register routes for custom actions with parent prefix

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -218,6 +218,11 @@ func (schema *Schema) GetActionURL(path string) string {
 	return schema.URL + path
 }
 
+// GetActionURLWithParents returns a URL for access to resources actions with parent suffix
+func (schema *Schema) GetActionURLWithParents(path string) string {
+	return schema.URLWithParents + path
+}
+
 // GetPluralURL returns a URL for access to all schema objects
 func (schema *Schema) GetPluralURL() string {
 	return schema.URL

--- a/server/api.go
+++ b/server/api.go
@@ -385,6 +385,9 @@ func MapRouteBySchema(server *Server, dataStore db.DB, s *schema.Schema) {
 			routes.ServeJson(w, context["response"])
 		}
 		route.AddRoute(action.Method, s.GetActionURL(action.Path), ActionFunc)
+		if s.ParentSchema != nil {
+			route.AddRoute(action.Method, s.GetActionURLWithParents(action.Path), ActionFunc)
+		}
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1147,12 +1147,19 @@ var _ = Describe("Server package test", func() {
 
 	Describe("Resource Actions", func() {
 		responderPluralURL := baseURL + "/v2.0/responders"
+		responderParentPluralURL := baseURL + "/v2.0/responder_parents"
 
 		BeforeEach(func() {
+			responderParent := map[string]interface{}{
+				"id": "p1",
+			}
+			testURL("POST", responderParentPluralURL, adminTokenID, responderParent, http.StatusCreated)
+
 			responder := map[string]interface{}{
-				"id":        "r1",
-				"pattern":   "Hello %s!",
-				"tenant_id": memberTenantID,
+				"id":                  "r1",
+				"pattern":             "Hello %s!",
+				"tenant_id":           memberTenantID,
+				"responder_parent_id": "p1",
 			}
 			testURL("POST", responderPluralURL, adminTokenID, responder, http.StatusCreated)
 		})
@@ -1173,6 +1180,17 @@ var _ = Describe("Server package test", func() {
 
 			result = testURL("POST", responderPluralURL+"/r1/hi", adminTokenID, testHiAction, http.StatusOK)
 			Expect(result).To(Equal([]interface{}{"Hi", "Heisenberg", "!"}))
+		})
+
+		It("should work with parent prefix", func() {
+			testHelloAction := map[string]interface{}{
+				"name": "Heisenberg",
+			}
+
+			result := testURL("POST", responderParentPluralURL+"/p1/responders/r1/hello", memberTokenID, testHelloAction, http.StatusOK)
+			Expect(result).To(Equal(map[string]interface{}{
+				"output": "Hello, Heisenberg!",
+			}))
 		})
 
 		It("should work without input shema", func() {

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -336,6 +336,7 @@ schemas:
   singular: admin_only
   title: Admin Only
 - description: Responder
+  parent: responder_parent
   id: responder
   plural: responders
   prefix: /v2.0
@@ -397,6 +398,23 @@ schemas:
       path: /:id/dobranoc
       output:
         type: string
-
+- description: ResponderParent
+  id: responder_parent
+  singular: reponder_parent
+  plural: responder_parents
+  prefix: /v2.0
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: true
+    propertiesOrder:
+    - id
+    type: object
+  title: Responder Parent
 
 subnets: []


### PR DESCRIPTION
When a schema with a parent resource type has custom actions,
add a route for the actions with the parent URL prefix.