### PR TITLE
Running extension tests in parallel

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -327,6 +328,7 @@ documentation for detail information about writing tests.`,
 			cli.BoolFlag{Name: "verbose, v", Usage: "Print logs for passing tests"},
 			cli.StringFlag{Name: "config-file,c", Value: "", Usage: "Config file path"},
 			cli.StringFlag{Name: "run-test,r", Value: "", Usage: "Run only tests matching specified regex"},
+			cli.IntFlag{Name: "parallel, p", Value: runtime.NumCPU(), Usage: "Allow parallel execution of test functions"},
 		},
 		Action: framework.TestExtensions,
 	}

--- a/vendor/github.com/tylerb/gls/LICENSE
+++ b/vendor/github.com/tylerb/gls/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Tyler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/tylerb/gls/README.md
+++ b/vendor/github.com/tylerb/gls/README.md
@@ -1,0 +1,14 @@
+gls [![GoDoc](https://godoc.org/github.com/tylerb/gls?status.png)](http://godoc.org/github.com/tylerb/gls) [![Build Status](https://drone.io/github.com/tylerb/gls/status.png)](https://drone.io/github.com/tylerb/gls/latest) [![Coverage Status](https://coveralls.io/repos/tylerb/gls/badge.svg?branch=master)](https://coveralls.io/r/tylerb/gls?branch=master)
+===
+
+GoRoutine local storage using GoRoutine IDs
+
+This package is heavily inspired by [jtolds](https://github.com/jtolds)' [gls](https://github.com/jtolds/gls) package.
+
+I made my own version of jtolds' package because [Brad Fitzpatrick](https://github.com/bradfitz) [created a function](https://github.com/bradfitz/http2/blob/dc0c5c000ec33e263612939744d51a3b68b9cece/gotrack.go) to get the current GoRoutine ID. Am I a horrible person for using this function? Probably.
+
+### Why is this useful? ###
+
+So far, the only thing I'm using it for is storing a unique identifier for a given HTTP request so I can track its progress through my code via logging. I felt this approach was easier and less messy than refactoring every function to take some kind of context or identifier.
+
+Enjoy!

--- a/vendor/github.com/tylerb/gls/gls.go
+++ b/vendor/github.com/tylerb/gls/gls.go
@@ -1,0 +1,111 @@
+// Package gls implements goroutine-local storage.
+package gls
+
+import "sync"
+
+// Values is simply a map of key types to value types. Used by SetValues to
+// set multiple values at once.
+type Values map[interface{}]interface{}
+
+var (
+	// dataLock protects access to the data map
+	dataLock sync.RWMutex
+	// data is a map of goroutine IDs that stores the key,value pairs
+	data map[uint64]Values
+)
+
+func init() {
+	data = map[uint64]Values{}
+}
+
+// With is a convenience function that stores the given values on this
+// goroutine, calls the provided function (which will have access to the
+// values) and then cleans up after itself.
+func With(values Values, f func()) {
+	SetValues(values)
+	f()
+	Cleanup()
+}
+
+// SetValues replaces all values for this goroutine.
+func SetValues(values Values) {
+	gid := curGoroutineID()
+	dataLock.Lock()
+	data[gid] = values
+	dataLock.Unlock()
+}
+
+// Set sets the value by key and associates it with the current goroutine.
+func Set(key string, value interface{}) {
+	gid := curGoroutineID()
+	dataLock.Lock()
+	if data[gid] == nil {
+		data[gid] = Values{}
+	}
+	data[gid][key] = value
+	dataLock.Unlock()
+}
+
+// Get gets the value by key as it exists for the current goroutine.
+func Get(key string) interface{} {
+	gid := curGoroutineID()
+	dataLock.RLock()
+	if data[gid] == nil {
+		dataLock.RUnlock()
+		return nil
+	}
+	value := data[gid][key]
+	dataLock.RUnlock()
+	return value
+}
+
+// Go creates a new goroutine and runs the provided function in that new
+// goroutine. It also associates any key,value pairs stored for the parent
+// goroutine with the child goroutine. This function must be used if you wish
+// to preserve the reference to any data stored in gls. This function
+// automatically cleans up after itself. Do not call cleanup in the function
+// passed to this function.
+func Go(f func()) {
+	parentData := getValues()
+	go func() {
+		linkGRs(parentData)
+		f()
+		unlinkGRs()
+	}()
+}
+
+// Cleanup removes all data associated with this goroutine. If this is not
+// called, the data may persist for the lifetime of your application. This
+// must be called from the very first goroutine to invoke Set
+func Cleanup() {
+	gid := curGoroutineID()
+	dataLock.Lock()
+	delete(data, gid)
+	dataLock.Unlock()
+}
+
+// getValues unlinks two goroutines
+func getValues() Values {
+	gid := curGoroutineID()
+	dataLock.Lock()
+	values := data[gid]
+	dataLock.Unlock()
+	return values
+}
+
+// linkGRs links two goroutines together, allowing the child to access the
+// data present in the parent.
+func linkGRs(parentData Values) {
+	childID := curGoroutineID()
+	dataLock.Lock()
+	data[childID] = parentData
+	dataLock.Unlock()
+}
+
+// unlinkGRs unlinks two goroutines
+func unlinkGRs() {
+	childID := curGoroutineID()
+	dataLock.Lock()
+	delete(data, childID)
+	dataLock.Unlock()
+}

--- a/vendor/github.com/tylerb/gls/gls_test.go
+++ b/vendor/github.com/tylerb/gls/gls_test.go
@@ -1,0 +1,108 @@
+package gls
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/tylerb/is"
+)
+
+func TestGLS(t *testing.T) {
+	is := is.New(t)
+
+	Set("key", "value")
+	v := Get("key")
+	is.NotNil(v)
+	is.Equal(v, "value")
+
+	Cleanup()
+}
+
+func TestGLSWith(t *testing.T) {
+	is := is.New(t)
+
+	With(Values{"key": "value"}, func() {
+		v := Get("key")
+		is.NotNil(v)
+		is.Equal(v, "value")
+	})
+
+	v := Get("key")
+	is.Nil(v)
+}
+
+func TestGLSSetValues(t *testing.T) {
+	is := is.New(t)
+
+	Set("key", "value")
+	v := Get("key")
+	is.NotNil(v)
+	is.Equal(v, "value")
+
+	SetValues(Values{"answer": 42})
+	v = Get("key")
+	is.Nil(v)
+
+	v = Get("answer")
+	is.NotNil(v)
+	is.Equal(v, 42)
+
+	Cleanup()
+}
+
+func TestGLSGo(t *testing.T) {
+	is := is.New(t)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	Set("key", "value")
+
+	Go(func() {
+		v := Get("key")
+		is.NotNil(v)
+		is.Equal(v, "value")
+		Go(func() {
+			v := Get("key")
+			is.NotNil(v)
+			is.Equal(v, "value")
+			Set("answer", 42)
+			Go(func() {
+				v := Get("key")
+				is.NotNil(v)
+				is.Equal(v, "value")
+				v = Get("answer")
+				is.NotNil(v)
+				is.Equal(v, 42)
+				wg.Done()
+			})
+			wg.Done()
+		})
+		wg.Done()
+	})
+
+	v := Get("key")
+	is.NotNil(v)
+	is.Equal(v, "value")
+
+	wg.Wait()
+
+	Cleanup()
+}
+
+func BenchmarkGLSSet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Set("key", "value")
+	}
+	Cleanup()
+}
+
+func BenchmarkGLSGet(b *testing.B) {
+	b.StopTimer()
+	Set("key", "value")
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		Get("key")
+	}
+	Cleanup()
+}

--- a/vendor/github.com/tylerb/gls/gotrack.go
+++ b/vendor/github.com/tylerb/gls/gotrack.go
@@ -1,0 +1,130 @@
+package gls
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"strconv"
+	"sync"
+)
+
+// Sourced https://github.com/bradfitz/http2/blob/dc0c5c000ec33e263612939744d51a3b68b9cece/gotrack.go
+var goroutineSpace = []byte("goroutine ")
+var littleBuf = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, 64)
+		return &buf
+	},
+}
+
+func curGoroutineID() uint64 {
+	bp := littleBuf.Get().(*[]byte)
+	defer littleBuf.Put(bp)
+	b := *bp
+	b = b[:runtime.Stack(b, false)]
+	// Parse the 4707 out of "goroutine 4707 ["
+	b = bytes.TrimPrefix(b, goroutineSpace)
+	i := bytes.IndexByte(b, ' ')
+	if i < 0 {
+		panic(fmt.Sprintf("No space found in %q", b))
+	}
+	b = b[:i]
+	n, err := parseUintBytes(b, 10, 64)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to parse goroutine ID out of %q: %v", b, err))
+	}
+	return n
+}
+
+// parseUintBytes is like strconv.ParseUint, but using a []byte.
+func parseUintBytes(s []byte, base int, bitSize int) (n uint64, err error) {
+	var cutoff, maxVal uint64
+
+	if bitSize == 0 {
+		bitSize = int(strconv.IntSize)
+	}
+
+	s0 := s
+	switch {
+	case len(s) < 1:
+		err = strconv.ErrSyntax
+		return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+
+	case 2 <= base && base <= 36:
+		// valid base; nothing to do
+
+	case base == 0:
+		// Look for octal, hex prefix.
+		switch {
+		case s[0] == '0' && len(s) > 1 && (s[1] == 'x' || s[1] == 'X'):
+			base = 16
+			s = s[2:]
+			if len(s) < 1 {
+				err = strconv.ErrSyntax
+				return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+			}
+		case s[0] == '0':
+			base = 8
+		default:
+			base = 10
+		}
+
+	default:
+		err = errors.New("invalid base " + strconv.Itoa(base))
+		return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+	}
+
+	n = 0
+	cutoff = cutoff64(base)
+	maxVal = 1<<uint(bitSize) - 1
+
+	for i := 0; i < len(s); i++ {
+		var v byte
+		d := s[i]
+		switch {
+		case '0' <= d && d <= '9':
+			v = d - '0'
+		case 'a' <= d && d <= 'z':
+			v = d - 'a' + 10
+		case 'A' <= d && d <= 'Z':
+			v = d - 'A' + 10
+		default:
+			n = 0
+			err = strconv.ErrSyntax
+			return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+		}
+		if int(v) >= base {
+			n = 0
+			err = strconv.ErrSyntax
+			return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+		}
+
+		if n >= cutoff {
+			// n*base overflows
+			n = 1<<64 - 1
+			err = strconv.ErrRange
+			return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+		}
+		n *= uint64(base)
+
+		n1 := n + uint64(v)
+		if n1 < n || n1 > maxVal {
+			// n+v overflows
+			n = 1<<64 - 1
+			err = strconv.ErrRange
+			return n, &strconv.NumError{Func: "ParseUint", Num: string(s0), Err: err}
+		}
+		n = n1
+	}
+
+	return n, nil
+}
+
+// Return the first number n such that n*base >= 1<<64.
+func cutoff64(base int) uint64 {
+	if base < 2 {
+		return 0
+	}
+	return (1<<64-1)/uint64(base) + 1
+}


### PR DESCRIPTION
This PR is a followup to https://github.com/cloudwan/gohan/pull/365. It adds possibility to run extension tests using all available CPU cores.

The observable change in run time is slight, profiling shows that it's caused by poor memory management in otto.

	Showing top 5 nodes out of 248 (cum >= 21.32s)
	flat  flat%   sum%        cum   cum%
	36.96s  7.07%  7.07%     70.73s 13.52%  runtime.scanobject
	33s  6.31% 13.38%    105.67s 20.20%  runtime.mallocgc
	24.01s  4.59% 17.97%     31.22s  5.97%  runtime.mapaccess2_faststr
	22.53s  4.31% 22.27%     22.53s  4.31%  runtime.readvarint
	21.32s  4.08% 26.35%     21.32s  4.08%  runtime.heapBitsForObject
	(pprof) top5 -cum
	0.45mins of 8.72mins total ( 5.17%)
	Dropped 1069 nodes (cum <= 0.04mins)
	Showing top 5 nodes out of 248 (cum >= 6.77mins)
	flat  flat%   sum%        cum   cum%
	0.26mins  2.98%  2.98%   6.79mins 77.84%  github.com/cloudwan/gohan/vendor/github.com/robertkrimen/otto.(*_runtime).cmpl_evaluate_nodeExpression
	0.10mins  1.12%  4.11%   6.78mins 77.84%  github.com/cloudwan/gohan/vendor/github.com/robertkrimen/otto.(*_runtime).cmpl_evaluate_nodeStatement
	0.02mins   0.2%  4.30%   6.78mins 77.84%  github.com/cloudwan/gohan/vendor/github.com/robertkrimen/otto.(*_runtime).cmpl_evaluate_nodeStatementList
	0.05mins  0.59%  4.89%   6.78mins 77.78%  github.com/cloudwan/gohan/vendor/github.com/robertkrimen/otto.(*_runtime).cmpl_evaluate_nodeCallExpression
	0.02mins  0.28%  5.17%   6.77mins 77.69%  github.com/cloudwan/gohan/vendor/github.com/robertkrimen/otto.(*_object).call

I tries fixing that you can [see the commit](https://github.com/mmatczuk/gohan/commit/1c638feffbd15007d82bf17d1b07dcdaea0116a4), the change is big the results still not satisfactory. I managed to reduce the allocations from 18MB to ~9MB this resulted in ~20 seconds improvement in ~5:30 test suite.