### PR TITLE
Time limit overrides for extensions

### DIFF
--- a/etc/gohan.yaml
+++ b/etc/gohan.yaml
@@ -68,3 +68,12 @@ extension:
   - gohanscript
  # - javascript
   - go
+
+  # default time limit in secs for running extension
+  timelimit: 10
+
+  # time limit overrides in secs for running particular extension in path
+  timelimits:
+  - path: /v1.0/store/orders
+    event: pre_*
+    timelimit: 1

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -17,13 +17,14 @@ package extension
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cloudwan/gohan/schema"
 )
 
 //Environment is a interface for extension environment
 type Environment interface {
-	LoadExtensionsForPath(extensions []*schema.Extension, path string) error
+	LoadExtensionsForPath(extensions []*schema.Extension, timeLimit time.Duration, timeLimits []*schema.PathEventTimeLimit, path string) error
 	HandleEvent(event string, context map[string]interface{}) error
 	Clone() Environment
 }

--- a/extension/extension_test.go
+++ b/extension/extension_test.go
@@ -18,7 +18,6 @@ package extension_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"time"
 
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/otto"
@@ -37,10 +36,8 @@ var _ = Describe("Environment manager", func() {
 	)
 
 	BeforeEach(func() {
-		env1 = otto.NewEnvironment("extension_test1",
-			testDB1, &middleware.FakeIdentity{}, time.Second, testSync)
-		env2 = otto.NewEnvironment("extension_test2",
-			testDB2, &middleware.FakeIdentity{}, time.Second, testSync)
+		env1 = otto.NewEnvironment("extension_test1", testDB1, &middleware.FakeIdentity{}, testSync)
+		env2 = otto.NewEnvironment("extension_test2", testDB2, &middleware.FakeIdentity{}, testSync)
 	})
 
 	JustBeforeEach(func() {

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/cloudwan/gohan/db"
 	"github.com/cloudwan/gohan/db/transaction"
@@ -31,7 +30,6 @@ import (
 	"github.com/cloudwan/gohan/sync/noop"
 	"github.com/robertkrimen/otto"
 
-	//Import otto underscore lib
 	_ "github.com/robertkrimen/otto/underscore"
 
 	gohan_otto "github.com/cloudwan/gohan/extension/otto"
@@ -76,7 +74,7 @@ func (env *Environment) InitializeEnvironment() error {
 	envName := strings.TrimSuffix(
 		filepath.Base(env.testFileName),
 		filepath.Ext(env.testFileName))
-	env.Environment = gohan_otto.NewEnvironment(envName, env.dbConnection, &middleware.FakeIdentity{}, 30*time.Second, noop.NewSync())
+	env.Environment = gohan_otto.NewEnvironment(envName, env.dbConnection, &middleware.FakeIdentity{}, noop.NewSync())
 	env.SetUp()
 	env.addTestingAPI()
 
@@ -418,5 +416,5 @@ func (env *Environment) loadExtensions() error {
 	}
 	pathString, _ := pathValue.ToString()
 
-	return env.LoadExtensionsForPath(manager.Extensions, pathString)
+	return env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, pathString)
 }

--- a/extension/gohanscript/env_test.go
+++ b/extension/gohanscript/env_test.go
@@ -32,11 +32,13 @@ import (
 
 var _ = Describe("Gohanscript extension manager", func() {
 	var (
-		timelimit time.Duration
+		timeLimit  time.Duration
+		timeLimits []*schema.PathEventTimeLimit
 	)
 
 	BeforeEach(func() {
-		timelimit = time.Second
+		timeLimit = time.Duration(10) * time.Second
+		timeLimits = []*schema.PathEventTimeLimit{}
 	})
 
 	AfterEach(func() {
@@ -51,7 +53,7 @@ var _ = Describe("Gohanscript extension manager", func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to clear table.")
 		}
 		err = tx.Commit()
-		Expect(err).ToNot(HaveOccurred(), "Failed to commite transaction.")
+		Expect(err).ToNot(HaveOccurred(), "Failed to commit transaction.")
 
 		extension.ClearManager()
 	})
@@ -69,8 +71,8 @@ var _ = Describe("Gohanscript extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := gohanscript.NewEnvironment(timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := gohanscript.NewEnvironment()
+				Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
 					"id": "test",
@@ -89,8 +91,8 @@ var _ = Describe("Gohanscript extension manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				extensions := []*schema.Extension{extension}
-				env := gohanscript.NewEnvironment(timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := gohanscript.NewEnvironment()
+				Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
 					"id": "test",
@@ -118,8 +120,8 @@ var _ = Describe("Gohanscript extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := gohanscript.NewEnvironment(timelimit)
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := gohanscript.NewEnvironment()
+				Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
 					"id": "test",
@@ -132,7 +134,7 @@ var _ = Describe("Gohanscript extension manager", func() {
 	})
 
 	var _ = Describe("Timeout", func() {
-		Context("stops if execution time exceeds timelimit", func() {
+		Context("stops if execution time exceeds timeLimit", func() {
 			It("Should work", func() {
 				extension, err := schema.NewExtension(map[string]interface{}{
 					"id": "infinite_loop",
@@ -146,8 +148,8 @@ var _ = Describe("Gohanscript extension manager", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
-				env := gohanscript.NewEnvironment(time.Duration(100))
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				env := gohanscript.NewEnvironment()
+				Expect(env.LoadExtensionsForPath(extensions, time.Duration(100), timeLimits, "test_path")).To(Succeed())
 				context := map[string]interface{}{
 					"id": "test",
 				}

--- a/extension/golang/env.go
+++ b/extension/golang/env.go
@@ -16,6 +16,8 @@
 package golang
 
 import (
+	"time"
+
 	ext "github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/schema"
 )
@@ -43,7 +45,7 @@ func (env *Environment) Load(source, code string) error {
 }
 
 //LoadExtensionsForPath for returns extensions for specific path
-func (env *Environment) LoadExtensionsForPath(extensions []*schema.Extension, path string) error {
+func (env *Environment) LoadExtensionsForPath(extensions []*schema.Extension, timeLimit time.Duration, timeLimits []*schema.PathEventTimeLimit, path string) error {
 	for _, extension := range extensions {
 		if extension.Match(path) {
 			if extension.CodeType != "go" {
@@ -73,7 +75,7 @@ func (env *Environment) HandleEvent(event string, context map[string]interface{}
 
 //Clone makes clone of the environment
 func (env *Environment) Clone() ext.Environment {
-	newEnv := NewEnvironment()
-	newEnv.goCallbacks = env.goCallbacks
-	return newEnv
+	clone := NewEnvironment()
+	clone.goCallbacks = env.goCallbacks
+	return clone
 }

--- a/extension/golang/env_test.go
+++ b/extension/golang/env_test.go
@@ -21,11 +21,23 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"time"
+
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/schema"
 )
 
 var _ = Describe("Gohanscript extension manager", func() {
+	var (
+		timeLimit  time.Duration
+		timeLimits []*schema.PathEventTimeLimit
+	)
+
+	BeforeEach(func() {
+		timeLimit = time.Duration(10) * time.Second
+		timeLimits = []*schema.PathEventTimeLimit{}
+	})
+
 	AfterEach(func() {
 		extension.ClearManager()
 	})
@@ -42,7 +54,7 @@ var _ = Describe("Gohanscript extension manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 				extensions := []*schema.Extension{extension}
 				env := golang.NewEnvironment()
-				Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+				Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "test_path")).To(Succeed())
 
 				context := map[string]interface{}{
 					"id": "test",

--- a/extension/multienv.go
+++ b/extension/multienv.go
@@ -15,7 +15,11 @@
 
 package extension
 
-import "github.com/cloudwan/gohan/schema"
+import (
+	"time"
+
+	"github.com/cloudwan/gohan/schema"
+)
 
 //MultiEnvironment can handle multiple environment
 type MultiEnvironment struct {
@@ -36,9 +40,9 @@ func (env *MultiEnvironment) SetUp() {
 }
 
 //LoadExtensionsForPath for returns extensions for specific path
-func (env *MultiEnvironment) LoadExtensionsForPath(extensions []*schema.Extension, path string) error {
+func (env *MultiEnvironment) LoadExtensionsForPath(extensions []*schema.Extension, timeLimit time.Duration, timeLimits []*schema.PathEventTimeLimit, path string) error {
 	for _, env := range env.childEnv {
-		err := env.LoadExtensionsForPath(extensions, path)
+		err := env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, path)
 		if err != nil {
 			return err
 		}

--- a/extension/otto/gohan_db_test.go
+++ b/extension/otto/gohan_db_test.go
@@ -35,11 +35,11 @@ import (
 )
 
 func newEnvironmentWithExtension(extension *schema.Extension, db db.DB) (env extension.Environment) {
-	timelimit := time.Duration(1) * time.Second
+	timeLimit := time.Duration(1) * time.Second
+	timeLimits := []*schema.PathEventTimeLimit{}
 	extensions := []*schema.Extension{extension}
-	env = otto.NewEnvironment("db_test",
-		db, &middleware.FakeIdentity{}, timelimit, testSync)
-	Expect(env.LoadExtensionsForPath(extensions, "test_path")).To(Succeed())
+	env = otto.NewEnvironment("db_test", db, &middleware.FakeIdentity{}, testSync)
+	Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "test_path")).To(Succeed())
 	return
 }
 

--- a/schema/manager.go
+++ b/schema/manager.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"sync"
 
+	"time"
+
 	"github.com/cloudwan/gohan/util"
 	"github.com/tylerb/gls"
 	"github.com/xeipuuv/gojsonschema"
@@ -39,6 +41,8 @@ type Manager struct {
 	schemaOrder []string
 	policies    []*Policy
 	Extensions  []*Extension
+	TimeLimit   time.Duration         // default time limit for an extension
+	TimeLimits  []*PathEventTimeLimit // a list of exceptions for time limits
 	namespaces  map[string]*Namespace
 	mu          sync.RWMutex
 }

--- a/schema/timelimits.go
+++ b/schema/timelimits.go
@@ -1,0 +1,61 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"regexp"
+	"time"
+)
+
+// PathEventTimeLimit is a configuration for
+// 	time limits for a regex path and a regex event
+type PathEventTimeLimit struct {
+	PathRegex    *regexp.Regexp
+	EventRegex   *regexp.Regexp
+	TimeDuration time.Duration
+}
+
+func NewPathEventTimeLimit(pathRegex, eventRegex string, timeDuration time.Duration) *PathEventTimeLimit {
+	return &PathEventTimeLimit{
+		PathRegex:    regexp.MustCompile(pathRegex),
+		EventRegex:   regexp.MustCompile(eventRegex),
+		TimeDuration: timeDuration,
+	}
+}
+
+//Match checks if this path matches for extension
+func (pathEventTimeLimit *PathEventTimeLimit) Match(path string) bool {
+	return pathEventTimeLimit.PathRegex.MatchString(path)
+}
+
+// EventTimeLimit is a configuration for
+// 	time limits for a regex event
+type EventTimeLimit struct {
+	EventRegex   *regexp.Regexp
+	TimeDuration time.Duration
+}
+
+func NewEventTimeLimit(eventRegex *regexp.Regexp, timeLimit time.Duration) *EventTimeLimit {
+	return &EventTimeLimit{
+		EventRegex:   eventRegex,
+		TimeDuration: timeLimit,
+	}
+}
+
+//Match checks if this path matches for extension
+func (eventTimeLimit *EventTimeLimit) Match(event string) bool {
+	return eventTimeLimit.EventRegex.MatchString(event)
+}

--- a/server/extension.go
+++ b/server/extension.go
@@ -33,7 +33,6 @@ package server
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/gohanscript"
@@ -44,14 +43,12 @@ import (
 
 func (server *Server) newEnvironment(name string) extension.Environment {
 	envs := []extension.Environment{}
-	timelimit := time.Duration(server.timelimit) * time.Second
 	for _, extension := range server.extensions {
 		switch extension {
 		case "javascript":
-			envs = append(envs, otto.NewEnvironment(name, server.db,
-					server.keystoneIdentity, timelimit, server.sync))
+			envs = append(envs, otto.NewEnvironment(name, server.db, server.keystoneIdentity, server.sync))
 		case "gohanscript":
-			envs = append(envs, gohanscript.NewEnvironment(timelimit))
+			envs = append(envs, gohanscript.NewEnvironment())
 		case "go":
 			envs = append(envs, golang.NewEnvironment())
 		}
@@ -62,9 +59,8 @@ func (server *Server) newEnvironment(name string) extension.Environment {
 // NewEnvironmentForPath creates an extension environment and loads extensions for path
 func (server *Server) NewEnvironmentForPath(name string, path string) (env extension.Environment, err error) {
 	manager := schema.GetManager()
-
 	env = server.newEnvironment(name)
-	err = env.LoadExtensionsForPath(manager.Extensions, path)
+	err = env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, path)
 	if err != nil {
 		err = fmt.Errorf("Extensions parsing error: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Server package test", func() {
 			Expect(err).ToNot(HaveOccurred(), "Failed to clear table.")
 		}
 		err = tx.Commit()
-		Expect(err).ToNot(HaveOccurred(), "Failed to commite transaction.")
+		Expect(err).ToNot(HaveOccurred(), "Failed to commit transaction.")
 	})
 
 	Describe("Http request", func() {


### PR DESCRIPTION
This commit adds a configuration option to setup orverrides
for the default time limit for running an extension. A single
setting consists of a regex path, a regex event name and
a time duration.

https://github.com/cloudwan/gohan/issues/361
