### PR TITLE
Added custom title to generated swagger documentation

### DIFF
--- a/cli/template.go
+++ b/cli/template.go
@@ -155,14 +155,14 @@ func doTemplate(c *cli.Context) {
 		util.ExitFatal(err)
 		return
 	}
-	if c.IsSet("split-by-resource-group") {
-		saveAllResources(schemas, tpl)
-		return
-	}
 	policies := manager.Policies()
 	policy := c.String("policy")
 	schemasPolicy := filterSchemasForPolicy(policy, policies, schemas)
-	output, err := tpl.Execute(pongo2.Context{"schemas": schemasPolicy})
+	if c.IsSet("split-by-resource-group") {
+		saveAllResources(schemasPolicy, tpl)
+		return
+	}
+	output, err := tpl.Execute(pongo2.Context{"schemas": schemasPolicy, "schemaName": "gohan API"})
 	if err != nil {
 		util.ExitFatal(err)
 		return
@@ -174,7 +174,7 @@ func doTemplate(c *cli.Context) {
 func saveAllResources(schemas []*schema.Schema, tpl *pongo2.Template) {
 	for _, resource := range getAllResourcesFromSchemas(schemas) {
 		resourceSchemas := filerSchemasByResource(resource, schemas)
-		output, _ := tpl.Execute(pongo2.Context{"schemas": resourceSchemas})
+		output, _ := tpl.Execute(pongo2.Context{"schemas": resourceSchemas, "schemaName": resource})
 		ioutil.WriteFile(resource+".json", []byte(output), 0644)
 	}
 }

--- a/etc/templates/openapi.tmpl
+++ b/etc/templates/openapi.tmpl
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "version": "0.1",
-        "title": "gohan API"
+        "title": "{{ schemaName }}"
     },
     "basePath": "/",
     "schemes": [


### PR DESCRIPTION
Added custom title to the template - this affects only "split-by-resource-group" option.
Additionally changed the order of methods so that "split-by-resource-group" can be used together with "policy".