### PR TITLE
Number as float

### DIFF
--- a/db/sql/test_fixture.json
+++ b/db/sql/test_fixture.json
@@ -1,8 +1,36 @@
 {
-    "tests": [
-        {"tenant_id": "tenant0", "test_string": "obj0"},
-        {"tenant_id": "tenant0", "test_string": "obj1"},
-        {"tenant_id": "tenant1", "test_string": "obj2"},
-        {"tenant_id": "tenant1", "test_string": "obj3"}
-    ]
+  "tests": [
+    {
+      "id": "0",
+      "tenant_id": "tenant0",
+      "test_string": "obj0",
+      "test_number": 0.0,
+      "test_integer": 0,
+      "test_bool": true
+    },
+    {
+      "id": "1",
+      "tenant_id": "tenant0",
+      "test_string": "obj1",
+      "test_number": -0.1,
+      "test_integer": -1,
+      "test_bool": true
+    },
+    {
+      "id": "2",
+      "tenant_id": "tenant1",
+      "test_string": "obj2",
+      "test_number": 0.2,
+      "test_integer": 2,
+      "test_bool": true
+    },
+    {
+      "id": "3",
+      "tenant_id": "tenant1",
+      "test_string": "obj3",
+      "test_number": -0.3,
+      "test_integer": 3,
+      "test_bool": true
+    }
+  ]
 }

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -368,12 +368,16 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 			})
@@ -527,12 +531,16 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 			})
@@ -778,12 +786,16 @@ var _ = Describe("Resource manager", func() {
 					"id":          resourceID1,
 					"tenant_id":   adminTenantID,
 					"test_string": "Steloj estas en ordo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 				memberResourceData = map[string]interface{}{
 					"id":          resourceID2,
 					"tenant_id":   powerUserTenantID,
 					"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+					"test_number": 0.5,
+					"test_integer": 1,
 					"test_bool":   false,
 				}
 			})
@@ -917,12 +929,16 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
@@ -1128,12 +1144,16 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
@@ -1368,6 +1388,8 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			fakeIdentity = &middleware.FakeIdentity{}
@@ -1434,12 +1456,16 @@ var _ = Describe("Resource manager", func() {
 				"id":          resourceID1,
 				"tenant_id":   adminTenantID,
 				"test_string": "Steloj estas en ordo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			memberResourceData = map[string]interface{}{
 				"id":          resourceID2,
 				"tenant_id":   powerUserTenantID,
 				"test_string": "Mi estas la pordo, mi estas la sxlosilo.",
+				"test_number": 0.5,
+				"test_integer": 1,
 				"test_bool":   false,
 			}
 			listContext = middleware.Context{}

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -300,7 +300,31 @@ schemas:
         - create
         - update
         title: Test string
-        type: string
+        type:
+        - string
+        - "null"
+        unique: false
+      test_number:
+        default: 0.5
+        description: Test number
+        permission:
+        - create
+        - update
+        title: Test number
+        type:
+        - number
+        - "null"
+        unique: false
+      test_integer:
+        default: 0
+        description: Test integer
+        permission:
+        - create
+        - update
+        title: Test integer
+        type:
+        - integer
+        - "null"
         unique: false
       test_bool:
         default: false
@@ -309,7 +333,9 @@ schemas:
         - create
         - update
         title: Test boolean
-        type: boolean
+        type:
+        - boolean
+        - "null"
         unique: false
     propertiesOrder:
     - id

--- a/tools/mysql.sh
+++ b/tools/mysql.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+docker run -d --name gohan-mysql \
+-e MYSQL_ROOT_PASSWORD=password \
+-e MYSQL_USER=gohan \
+-e MYSQL_PASSWORD=gohan \
+-e MYSQL_DATABASE=gohan_test \
+-p 127.0.0.1:3306:3306 \
+mysql:5.5


### PR DESCRIPTION
This PR introduces distinction between types `number` and `integer` to conform to JSON spec where number is double-precision floating-point.

See https://github.com/cloudwan/gohan/issues/359.