### PR TITLE
Store watch revisions and use them on start

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   pre:
-    - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz
+    - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
     - sudo rm -rf /usr/local/go
     - sudo tar -C /usr/local -xzf go.tar.gz
     - sudo chmod a+w /usr/local/go/src/

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ import (
 	srv "github.com/cloudwan/gohan/server"
 	"github.com/cloudwan/gohan/server/middleware"
 	gohan_sync "github.com/cloudwan/gohan/sync"
-	gohan_etcd "github.com/cloudwan/gohan/sync/etcd"
+	gohan_etcd "github.com/cloudwan/gohan/sync/etcdv3"
 	"github.com/cloudwan/gohan/util"
 )
 
@@ -651,9 +652,10 @@ var _ = Describe("Server package test", func() {
 
 			Expect(server.Sync()).To(Succeed())
 
-			sync := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"})
+			sync, err := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"}, time.Second)
+			Expect(err).ToNot(HaveOccurred())
 
-			writtenConfig, err := sync.Fetch("/config/" + networkResource.Path())
+			writtenConfig, err := sync.Fetch("/config" + networkResource.Path())
 			Expect(err).ToNot(HaveOccurred())
 
 			var configContentsRaw interface{}
@@ -697,9 +699,10 @@ var _ = Describe("Server package test", func() {
 
 				Expect(server.Sync()).To(Succeed())
 
-				sync := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"})
+				sync, err := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"}, time.Second)
+				Expect(err).ToNot(HaveOccurred())
 
-				writtenConfig, err := sync.Fetch("/config/" + resource.Path())
+				writtenConfig, err := sync.Fetch("/config" + resource.Path())
 				Expect(err).ToNot(HaveOccurred())
 
 				var configContentsRaw interface{}
@@ -744,9 +747,10 @@ var _ = Describe("Server package test", func() {
 
 				Expect(server.Sync()).To(Succeed())
 
-				sync := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"})
+				sync, err := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"}, time.Second)
+				Expect(err).ToNot(HaveOccurred())
 
-				writtenConfig, err := sync.Fetch("/config/" + resource.Path())
+				writtenConfig, err := sync.Fetch("/config" + resource.Path())
 				Expect(err).ToNot(HaveOccurred())
 
 				var configContentsRaw map[string]interface{}
@@ -785,9 +789,10 @@ var _ = Describe("Server package test", func() {
 
 				Expect(server.Sync()).To(Succeed())
 
-				sync := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"})
+				sync, err := gohan_etcd.NewSync([]string{"http://127.0.0.1:2379"}, time.Second)
+				Expect(err).ToNot(HaveOccurred())
 
-				writtenConfig, err := sync.Fetch("/config/" + resource.Path())
+				writtenConfig, err := sync.Fetch("/config" + resource.Path())
 				Expect(err).ToNot(HaveOccurred())
 				Expect(writtenConfig.Value).To(BeEquivalentTo("property0"))
 

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -9,6 +9,7 @@ schemas:
     - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"
+sync: etcdv3
 etcd:
     - "http://127.0.0.1:2379"
 keystone:

--- a/server/server_test_mysql_config.yaml
+++ b/server/server_test_mysql_config.yaml
@@ -10,6 +10,7 @@ schemas:
     - "../tests/test_two_same_relations_schema.yaml"
 address: ":19090"
 document_root: "embed"
+sync: etcdv3
 etcd:
     - "http://127.0.0.1:2379"
 keystone:


### PR DESCRIPTION
Not to get all entries on ETCD, store last seen revisions to ETCD and
start watching from them on boot.