### PR TITLE
fix extension builtin sync watch leaks

### DIFF
--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -45,6 +45,10 @@ func (rh *responseHijacker) Write(b []byte) (int, error) {
 	return rh.ResponseWriter.Write(b)
 }
 
+func (rh *responseHijacker) CloseNotify() <-chan bool {
+	return rh.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
 //Logging logs requests and responses
 func Logging() martini.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c martini.Context) {


### PR DESCRIPTION
 - fix bug where stopChan wasn't set, which caused goroutine leak
 - fix environment timeout not being respected when extension is
    waiting on gohan_sync_watch. It's general issue for builtins, but
    this commit provides a fix for gohan_sync_watch
 - trigger extension interrupt when server detects client connection
    closed. This prevents CLOSE_WAIT connections stacking up when
    handling Long Poll and memory leaks