### PR TITLE
Cron fixes

### DIFF
--- a/server/cron.go
+++ b/server/cron.go
@@ -63,6 +63,9 @@ func startCRONProcess(server *Server) {
 			}
 
 			defer func() {
+				if r := recover(); r != nil {
+					log.Error("Cron job '%s' panicked: %s", path, r)
+				}
 				log.Debug("Unlocking %s", lockKey)
 				jobLocks[lockKey] <- 1
 			}()
@@ -74,7 +77,8 @@ func startCRONProcess(server *Server) {
 				log.Warning(fmt.Sprintf("extension error: %s", err))
 				return
 			}
-			if err := env.HandleEvent("notification", context); err != nil {
+			clone := env.Clone()
+			if err := clone.HandleEvent("notification", context); err != nil {
 				log.Warning(fmt.Sprintf("extension error: %s", err))
 				return
 			}


### PR DESCRIPTION
This PR contain two changes in cron job handling. I've included @marcin-ptaszynski  commit, for easier merge.

**@marcin-ptaszynski change:**
- use environment Clone instead of reusing it between jobs
 - recover from panic with log.Error message instead of crashing
   whole server.

**My change:**
Proper synchronization of cron jobs 
Gohan server uses ETCDv3 as sync.
In etcd lock can be acquired multiple times without unlocking only when same process acquires it.
In cron implementation this situation happened, so locking wasn't really lock anything,
which leads to multiple cron jobs doing its job in separate goroutines on shared not protected objects.
Cron job scheduled every 5s, would spawn two concurrently ran goroutines if first would take more than 5s.

Proposed lock solves this problem, and kill goroutine if previous job hasn't finished yet.
Another improvement would be to add timeout for job, but this is not part of this bug.
