### PR TITLE
added database/auto_migrate config flag

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -228,7 +228,7 @@ Useful for development purposes.`,
 			cascade := c.Bool("cascade")
 			manager := schema.GetManager()
 			manager.LoadSchemasFromFiles(schemaFile, metaSchemaFile)
-			err := db.InitDBWithSchemas(dbType, dbConnection, dropOnCreate, cascade)
+			err := db.InitDBWithSchemas(dbType, dbConnection, dropOnCreate, cascade, false)
 			if err != nil {
 				util.ExitFatal(err)
 			}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Database operation test", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, s := range manager.Schemas() {
-				Expect(dataStore.RegisterTable(s, false)).To(Succeed())
+				Expect(dataStore.RegisterTable(s, false, true)).To(Succeed())
 			}
 
 			tx, err = dataStore.Begin()
@@ -263,7 +263,7 @@ var _ = Describe("Database operation test", func() {
 		})
 
 		It("Should initialize the database without error", func() {
-			Expect(db.InitDBWithSchemas(dbType, conn, false, false)).To(Succeed())
+			Expect(db.InitDBWithSchemas(dbType, conn, false, false, true)).To(Succeed())
 		})
 	})
 
@@ -277,12 +277,12 @@ var _ = Describe("Database operation test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove("test_data/conv_in.db")
 
-			db.InitDBWithSchemas("sqlite3", "test_data/conv_out.db", false, false)
+			db.InitDBWithSchemas("sqlite3", "test_data/conv_out.db", false, false, true)
 			outDB, err := db.ConnectDB("sqlite3", "test_data/conv_out.db", db.DefaultMaxOpenConn)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove("test_data/conv_out.db")
 
-			db.InitDBWithSchemas("yaml", "test_data/conv_verify.yaml", false, false)
+			db.InitDBWithSchemas("yaml", "test_data/conv_verify.yaml", false, false, true)
 			verifyDB, err := db.ConnectDB("yaml", "test_data/conv_verify.yaml", db.DefaultMaxOpenConn)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove("test_data/conv_verify.yaml")
@@ -320,7 +320,7 @@ var _ = Describe("Database operation test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove("test_data/conv_in.db")
 
-			db.InitDBWithSchemas("sqlite3", "test_data/conv_out.db", false, false)
+			db.InitDBWithSchemas("sqlite3", "test_data/conv_out.db", false, false, true)
 			outDB, err := db.ConnectDB("sqlite3", "test_data/conv_out.db", db.DefaultMaxOpenConn)
 			Expect(err).ToNot(HaveOccurred())
 			defer os.Remove("test_data/conv_out.db")

--- a/db/file/file.go
+++ b/db/file/file.go
@@ -76,7 +76,7 @@ func (tx *Transaction) Closed() bool {
 }
 
 //RegisterTable register table definition
-func (db *DB) RegisterTable(s *schema.Schema, cascade bool) error {
+func (db *DB) RegisterTable(s *schema.Schema, cascade, migrate bool) error {
 	return nil
 }
 

--- a/db/mocks/db.go
+++ b/db/mocks/db.go
@@ -66,14 +66,14 @@ func (_mr *_MockDBRecorder) Begin() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Begin")
 }
 
-func (_m *MockDB) RegisterTable(_param0 *schema.Schema, _param1 bool) error {
-	ret := _m.ctrl.Call(_m, "RegisterTable", _param0, _param1)
+func (_m *MockDB) RegisterTable(s *schema.Schema, cascade bool, migrate bool) error {
+	ret := _m.ctrl.Call(_m, "RegisterTable", s, cascade, migrate)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDBRecorder) RegisterTable(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTable", arg0, arg1)
+func (_mr *_MockDBRecorder) RegisterTable(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTable", arg0, arg1, arg2)
 }
 
 func (_m *MockDB) DropTable(_param0 *schema.Schema) error {

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -393,11 +393,16 @@ func (db *DB) GenTableDef(s *schema.Schema, cascade bool) (string, []string) {
 }
 
 //RegisterTable creates table in the db
-func (db *DB) RegisterTable(s *schema.Schema, cascade bool) error {
+func (db *DB) RegisterTable(s *schema.Schema, cascade, migrate bool) error {
 	if s.IsAbstract() {
 		return nil
 	}
 	tableDef, indices, err := db.AlterTableDef(s, cascade)
+	if !migrate {
+		if tableDef != "" || (indices != nil && len(indices) > 0) {
+			return fmt.Errorf("needs migration, run \"gohan migrate\"")
+		}
+	}
 	if err != nil {
 		tableDef, indices = db.GenTableDef(s, cascade)
 	}

--- a/db/sql/sql_test.go
+++ b/db/sql/sql_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Sql", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(manager.LoadSchemasFromFiles(
 			"../../etc/schema/gohan.json", "../../tests/test_abstract_schema.yaml", "../../tests/test_schema.yaml")).To(Succeed())
-		db.InitDBWithSchemas(dbType, conn, true, false)
+		db.InitDBWithSchemas(dbType, conn, true, false, false)
 
 		// Insert fixture data
 		fixtureDB, err := db.ConnectDB("json", testFixtures, db.DefaultMaxOpenConn)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -188,7 +188,7 @@ In addition to resource related commands, some formatting commands are available
 
   - `json`, e.g:
 
-```
+```json
       {
         "name": "Resource name",
         "description": "Resource very long and meaningful description",
@@ -275,7 +275,7 @@ in GET requests, together with additional information about the state.
 
 For example say a simplistic resource with the following schema is created:
 
-```
+```yaml
     - description: Just a named object
       id: named_object
       parent: ""
@@ -313,7 +313,7 @@ and the ``name`` is set to ``Alice``. Then Gohan, through the standard event syn
 writes the following JSON object to the backend under the key
 ``config/v1.0/named_object/someGeneratedUuid``:
 
-```
+```json
     {
       "body": {
         "id": "someGeneratedUuid",
@@ -327,7 +327,7 @@ A worker program might now read this information, create a corresponding
 southbound resource and write the following to the backend under the key
 ``state/v1.0/named_object/someGeneratedUuid``:
 
-```
+```json
     {
       "version": 1,
       "error": "",
@@ -352,7 +352,7 @@ in the southbound a worker program might monitor its status and then write
 the result of this monitoring under the key
 ``monitoring/v1.0/named_object/someGeneratedUuid`` as the following JSON:
 
-```
+```json
     {
       "version": 1,
       "monitoring": "Alice is well"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,8 @@ Note that there are some example configurations in the etc directory.
 Gohan server configuration uses YAML format.
 (For YAML specification, see http://yaml.org/)
 
-```  #######################################################
+```yaml
+  #######################################################
   #  Gohan API Server example configuraion
   ######################################################
 
@@ -81,7 +82,7 @@ Note that overwrapped configuration will be overridden by configuration loaded l
 
 You can use Environment value in the configuration.
 
-```
+```yaml
   address: {{ .GOHAN_IP}}:{{ .GOHAN_PORT}}
 ```
 
@@ -98,7 +99,7 @@ You can select from sqlite3 and MySQL.
 
 a sample database configuraion for sqlite3.
 
-```
+```yaml
   # database connection configuraion
   database:
       type: "sqlite3"
@@ -107,7 +108,7 @@ a sample database configuraion for sqlite3.
 
 a sample database configuraion for sqlite3.
 
-```
+```yaml
   # database connection configuraion
   database:
       type: "mysql"
@@ -116,7 +117,7 @@ a sample database configuraion for sqlite3.
 
 a sample database configuration for YAML backend.
 
-```
+```yaml
   database:
       type: "yaml"
       connection: "./etc/example.yaml"
@@ -127,7 +128,7 @@ a sample database configuration for YAML backend.
 
 Cascade deletion, i.e. creating FOREIGN KEYs with CASCADE ON DELETE,  can be activated with cascade switch.
 
-```
+```yaml
   database:
       type: "mysql"
       connection: "root:gohan@127.0.0.1/gohan"
@@ -139,7 +140,7 @@ Cascade deletion, i.e. creating FOREIGN KEYs with CASCADE ON DELETE,  can be act
 Gohan works based on schema definitions.
 Developers should specify a list of schema file in the configuration.
 
-```
+```yaml
 schemas:
     - "embed://etc/schema/gohan.json"
     - "embed://etc/extensions/gohan_extension.yaml"
@@ -186,7 +187,7 @@ Gohan supports OpenStack Keystone authentication backend.
 
   v2.0 or v3 is supported
 
-```
+```yaml
   keystone:
       use_keystone: false
       fake: true
@@ -203,7 +204,7 @@ javascript WebUI without a proxy server.
 You need to specify allowed domain pattern in CORS parameter.
 Note: DO NOT USE * configuraion in production deployment.
 
-```
+```yaml
   cors: "*"
 ```
 
@@ -215,7 +216,7 @@ Developers can specify Logging level per log and per module in log. If a module 
 
 Allowed log levels: "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
 
-```
+```yaml
   logging:
       stderr:
           enabled: true
@@ -248,7 +249,7 @@ Allowed log levels: "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
   Location of the key file is matching with a certificate.
   e.g. ``"./etc/key.pem"``
 
-```
+```yaml
   tls:
     enabled: true
     cert_file: "./etc/cert.pem"
@@ -267,7 +268,7 @@ Files stored under "etc/schema" and "etc/extensions".
 
 You can select extension types you use.
 
-```
+```yaml
   extension:
     default: javascript
     use:
@@ -280,7 +281,7 @@ You can select extension types you use.
 
   You can make timelimit for extension execution. Default is 30 sec
 
-```
+```yaml
   extension:
     timelimit: 30
 ```
@@ -289,7 +290,7 @@ You can select extension types you use.
 
   You can set npm_path for extensions. It should point to a directory of node_modules. The default is the current working directory.
 
-```
+```yaml
   extension:
     npm_path: .
 ```
@@ -314,7 +315,7 @@ You can select extension types you use.
 
   list of etcd backend.
 
-```
+```yaml
   etcd:
       - "http://192.0.0.1:2379"
       - "http://192.0.0.2:2379"
@@ -331,7 +332,7 @@ a sample configuration.
 - events list of an event we invokes an extension
 - worker_count: number of concurrent execution tasks
 
-```
+```yaml
   watch:
       keys:
         - v2.0
@@ -350,7 +351,7 @@ WARNING: The value of watched etcd keys must be a JSON dictionary.
   You can also run extension for amqp based event specifying path for
   amqp://{{event_type}}.
 
-```
+```yaml
   amqp:
       connection: amqp://guest:guest@172.16.25.130:5672/
       queues:
@@ -365,7 +366,7 @@ WARNING: The value of watched etcd keys must be a JSON dictionary.
  You can listen to snmp trap, and execute extension for that trap.
  An extension path should be snmp://
 
-```
+```yaml
   snmp:
     address: "localhost:8888"
 ```
@@ -374,7 +375,7 @@ WARNING: The value of watched etcd keys must be a JSON dictionary.
 
   You can periodically execute CRON job using configuration.
 
-```
+```yaml
   cron:
       - path: cron://cron_job_sample
         timing: "*/5 * * * * *"
@@ -385,7 +386,7 @@ WARNING: The value of watched etcd keys must be a JSON dictionary.
   Gohan uses background job queue & workers.
   You can decide how many worker can run concurrently.
 
-```
+```yaml
    workers: 100
 ```
 
@@ -395,7 +396,7 @@ WARNING: The value of watched etcd keys must be a JSON dictionary.
   Gohan updates this file based on schema REST API call.
 
 
-```
+```yaml
    editable_schema: ./example_schema.yaml
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,8 @@ Gohan server configuration uses YAML format.
       # connection string
       # it is file path for yaml, json and sqlite3 backend
       connection: "./etc/test.db"
+      # should database be altered if schema was updated, default true
+      # auto_migrate: true
       # please set no_init true in the production env, so that gohan don't initialize table
       # no_init: true
       initial_data:
@@ -91,22 +93,12 @@ your environment key.
 We are using Golang text template package, so please take a
 look more at https://golang.org/pkg/text/template/
 
-Database
---------------------
+## Database
 
 This section is for backend database configuration.
-You can select from sqlite3 and MySQL.
+You can select from MySQL, sqlite3 and YAML.
 
-a sample database configuraion for sqlite3.
-
-```yaml
-  # database connection configuraion
-  database:
-      type: "sqlite3"
-      connection: "./sqlite3.db"
-```
-
-a sample database configuraion for sqlite3.
+Sample database configuration for MySQL.
 
 ```yaml
   # database connection configuraion
@@ -115,7 +107,16 @@ a sample database configuraion for sqlite3.
       connection: "root:gohan@127.0.0.1/gohan"
 ```
 
-a sample database configuration for YAML backend.
+Sample database configuration for sqlite3.
+
+```yaml
+  # database connection configuraion
+  database:
+      type: "sqlite3"
+      connection: "./sqlite3.db"
+```
+
+Sample database configuration for YAML backend.
 
 ```yaml
   database:
@@ -126,13 +127,31 @@ a sample database configuration for YAML backend.
             connection: "./etc/examples/initial_datayaml"
 ```
 
-Cascade deletion, i.e. creating FOREIGN KEYs with CASCADE ON DELETE,  can be activated with cascade switch.
+Cascade deletion, i.e. creating FOREIGN KEYs with CASCADE ON DELETE, can be activated with `cascade` switch.
 
 ```yaml
   database:
       type: "mysql"
       connection: "root:gohan@127.0.0.1/gohan"
       cascade: true
+```
+
+Disable database initialisation, set `no_init: true` in production env, so that gohan don't initialize table.
+
+```yaml
+  database:
+      type: "mysql"
+      connection: "root:gohan@127.0.0.1/gohan"
+      no_init: true
+```
+
+Disable auto migrations, set `auto_migrate: false` so that gohan don't alter database tables, it can, however, add new tables. 
+
+```yaml
+  database:
+      type: "mysql"
+      connection: "root:gohan@127.0.0.1/gohan"
+      auto_migrate: false
 ```
 
 ## Schema

--- a/docs/database.md
+++ b/docs/database.md
@@ -44,7 +44,6 @@ Gohan supports generating goose (https://bitbucket.org/liamstask/goose) migratio
 Currently, Gohan doesn't provide function calculating diff on a schema, so that app developers should manage this migration script.
 
 ```
-
   NAME:
      migrate - Generate goose migration script
 

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -11,7 +11,7 @@ Extensions has properties:
 
 Example Code
 
-```
+```yaml
   extensions:
   - code: console.log(Object.keys(context));
     id: test
@@ -189,7 +189,7 @@ You can implement Gohan extension by native go.
 You can use "go" for code_type and specify your callback id in code.
 Also, you can register go struct & call it from javascript.
 
-```
+```yaml
   extensions:
   - code: exampleapp_callback
     code_type: go
@@ -197,7 +197,7 @@ Also, you can register go struct & call it from javascript.
     path: .*
 ```
 
-```
+```go
   //Register go callback
   extension.RegisterGoCallback("exampleapp_callback",
   	func(event string, context map[string]interface{}) error {

--- a/docs/gohan_extension.md
+++ b/docs/gohan_extension.md
@@ -8,7 +8,7 @@ for extending your Go code with MACRO functionality.
 
 ## Example
 
-```
+```yaml
 extensions:
 - id: order
   path: /v1.0/store/orders
@@ -51,7 +51,7 @@ extensions:
 
 ## Standalone Example
 
-```
+```yaml
     vars:
       world: "USA"
       foods:
@@ -105,7 +105,7 @@ gohan run ../examples/sample1.yaml
 
 You can run list of tasks.
 
-```
+```yaml
   tasks:
   - debug: msg="Hello World"
   - debug: msg="This is gohan script"
@@ -123,7 +123,7 @@ $ gohan run hello_world.yaml
 
 You can define variables using "vars".
 
-```
+```yaml
   tasks:
   - vars:
       place: "Earth"
@@ -159,7 +159,7 @@ a variable identifier.
 
 You can loop over the list item.
 
-```
+```yaml
     vars:
         foods:
         - apple
@@ -187,7 +187,7 @@ You can loop over the list item.
 
 You can also loop over a dict.
 
-```
+```yaml
     vars:
     person:
         name: "John"
@@ -209,7 +209,7 @@ You can also loop over a dict.
     15:32:42.513 ▶ DEBUG  with_items.yaml:9 age 30
 ```
 
-```
+```yaml
     tasks:
     - vars:
         result: ""
@@ -235,7 +235,7 @@ You can also loop over a dict.
 You can use "when" for conditional.
 You can use "else" blocks with "when".
 
-```
+```yaml
     vars:
       number: 1
     tasks:
@@ -259,7 +259,7 @@ You can retry task.
 - retry: how many times you will retry a task
 - delay: how many seconds you will wait on next retry
 
-```
+```yaml
     tasks:
     - fail: msg="Failed"
       retry: 3
@@ -278,7 +278,7 @@ You can retry task.
 You can group a set of tasks using blocks.
 blocks also supports loops, conditional and retries.
 
-```
+```yaml
     tasks:
     - blocks:
       - debug: msg="hello"
@@ -295,7 +295,7 @@ blocks also supports loops, conditional and retries.
 
 You can change variable value using "register".
 
-```
+```yaml
     tasks:
     - http_get: url=https://status.github.com/api/status.json
       register: result
@@ -313,7 +313,7 @@ We support concurrent execution over a loop.
 
 - worker: specify number of max workers
 
-```
+```yaml
     tasks:
     - blocks:
       - http_get: url="https://status.github.com/{{ item }}"
@@ -335,7 +335,7 @@ We support concurrent execution over a loop.
 
 You can also execute tasks in background.
 
-```
+```yaml
     tasks:
     - background:
       - sleep: 1000
@@ -361,7 +361,7 @@ You can define function using "define" task.
 - args: arguments
 - body: body of code
 
-```
+```yaml
     tasks:
     - define:
         name: fib
@@ -399,7 +399,7 @@ you can use return task in function block.
 
 You can include gohan script
 
-```
+```yaml
     tasks:
     - include: lib.yaml
 ```
@@ -413,7 +413,7 @@ You can include gohan script
 
 You can set breakpoint using "debugger"
 
-```
+```yaml
     vars:
     world: "USA"
     foods:
@@ -448,12 +448,12 @@ additional arguments will be stored in variable.
 If the value doesn't contain "=", it will be pushed to args.
 If the value contains "=", it get splitted for key and value and stored in flags.
 
-```
+```yaml
     tasks:
     - debug: msg="{{ flags.greeting }} {{ args.0 }}"
 ```
 
-```
+```yaml
 $ gohan run args.yaml world greeting=hello
 hello world
 ```
@@ -470,7 +470,7 @@ in the specified directory.
 
 ## Run Gohan script from Go
 
-```
+```go
 	vm := gohan.NewVM()
 	_, err := vm.RunFile("test/spec.yaml")
 	if err != nil {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@ github release page.
 # Packages
 
 ## Ubuntu 14.04 Trusty 64bits server
-```
+```bash
 wget -qO - https://deb.packager.io/key | sudo apt-key add -
 echo "deb https://deb.packager.io/gh/cloudwan/gohan trusty master" | sudo tee /etc/apt/sources.list.d/gohan.list
 sudo apt-get update
@@ -25,7 +25,7 @@ sudo apt-get install gohan
 ```
 ## CentOS / RHEL 6 64 bits server
 
-```
+```bash
 sudo rpm --import https://rpm.packager.io/key
 echo "[gohan]
 name=Repository for cloudwan/gohan application.
@@ -36,7 +36,7 @@ sudo yum install gohan
 
 ## Debian 7 Wheezy 64bits server
 
-```
+```bash
 wget -qO - https://deb.packager.io/key | sudo apt-key add -
 echo "deb https://deb.packager.io/gh/cloudwan/gohan wheezy master" | sudo tee /etc/apt/sources.list.d/gohan.list
 sudo apt-get update

--- a/docs/js_extension.md
+++ b/docs/js_extension.md
@@ -377,7 +377,7 @@ following API:
 ## Example
 A sample test may look like this:
 
-```
+```yaml
   // Schema file containing extensions to be tested
   var SCHEMA = "../test_schema.yaml";
 

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -12,7 +12,7 @@ Namespace has the following properties:
 
 Example namespace
 
-```
+```yaml
   namespaces:
   - description: Neutron API
     id: neutron

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -28,7 +28,7 @@ Gohan supports several types of conditions
 
 Example policy
 
-``` yaml
+```yaml
   policies:
   - action: '*'
     effect: allow
@@ -81,7 +81,7 @@ Example policy
   if it is a dict, we check if we have a key for this value and, updated value matches it.
   Note that this is only valid for update action.
 
-``` yaml
+```yaml
     policy:
       - action: 'read'
         condition:
@@ -133,7 +133,7 @@ With a special type of policy one can define a resource path that do not require
 In this policy only 'id', 'principal' and 'resource.path' properties are used. Policy 'principal'
 is always set to 'Nobody'.
 
-``` yaml
+```yaml
 policies:
 - id: no_auth_favicon
   principal: Nobody

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -27,7 +27,7 @@ Schemas might also have any of the following optional properties.
 Gohan supports mix-in of multiple schemas.
 Developers can make a schema as abstract schema specifying type=abstract. The developer can mix-in abstract schema.
 
-```
+```yaml
   schemas:
   - description: base
     type: abstract
@@ -217,7 +217,7 @@ You can use following parameters for a string.
 - on_delete_cascade  (extended spec by Gohan) cascading delete when related resource deleted
 
 eg.
-```
+```yaml
         name:
           permission:
           - create
@@ -233,7 +233,7 @@ type boolean for boolean value
 
 eg.
 
-```
+```yaml
         admin_state:
           permission:
           - create
@@ -253,7 +253,7 @@ You can use following parameters to define valid range
 
 eg.
 
-```
+```yaml
         age:
           permission:
           - create
@@ -274,7 +274,7 @@ type array is for a defining list of elements
 
 eg.
 
-```
+```yaml
         route_targets:
           default: []
           items:
@@ -305,7 +305,7 @@ Following parameters supported in the object type.
 
 eg.
 
-```
+```yaml
         providor_networks:
           default: {}
           permission:
@@ -338,7 +338,7 @@ Gohan adds <parent>_id property automatically when Gohan loads schemas.
 
 eg.
 
-```
+```yaml
         schemas:
         - description: Test Device
           id: test_device
@@ -399,7 +399,7 @@ Resources can have custom actions, besides CRUD. To define them, add "actions" s
 
 eg.
 
-```
+```yaml
         schemas:
         - description: Server
           id: server
@@ -456,7 +456,7 @@ Then, register extension to handle it, e.g.
 
 In order to query above action, POST to /v1.0/servers/:id/action with
 
-```
+```yaml
   {
     "reboot": {
       "message": "Maintenance",
@@ -470,7 +470,7 @@ In order to query above action, POST to /v1.0/servers/:id/action with
 Developers can specify the transaction isolation level for API requests when Gohan is configured to connect MySQL database.
 The default setting is "read repeatable" for read operations and "serializable" for operations that modify the database (create, update, delete) and sync operation. (state_update, monitoring_update). The default for unspecified action is repeatable read.
 
-```
+```yaml
     isolation_level:
       read:  REPEATABLE READ
       create:  SERIALIZABLE
@@ -540,7 +540,7 @@ Response will be
 
 HTTP Status Code: 200
 
-```
+```json
 
   {
     "$plural": [
@@ -576,7 +576,7 @@ Response will be
 
 HTTP Status Code: 200
 
-```
+```json
   {
     "$singular": {
       "attr1": XX,
@@ -597,7 +597,7 @@ Note that input JSON can only contain if you set "create" permission for this
 
 HTTP Status Code: 202
 
-```
+```json
   {
     "$singular": {
       "attr1": XX,
@@ -608,7 +608,7 @@ HTTP Status Code: 202
 
 Response will be
 
-```
+```json
   {
     "$singular": {
       "attr1": XX,
@@ -627,7 +627,7 @@ Input
 
 Note that input JSON can only contain if you set "update" permission for this
 
-```
+```json
   {
     "$singular": {
       "attr1": XX,
@@ -640,7 +640,7 @@ Response will be
 
 HTTP Status Code: 200
 
-```
+```json
   {
     "$singular": {
       "attr1": XX,
@@ -668,7 +668,7 @@ Input
 
 Input JSON can only contain parameters defined in the input schema definition. It requires "$action" allow policy
 
-```
+```json
   {
     "parameter1": XX,
     "parameter2": XX
@@ -679,7 +679,7 @@ Response will be
 
 HTTP Status Code: 200
 
-```
+```json
   {
     "output1": XX,
     "output2": XX

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -113,7 +113,7 @@ func (env *Environment) InitializeEnvironment() error {
 		return fmt.Errorf("Failed to load extensions for '%s': %s", env.testFileName, err)
 	}
 
-	err = db.InitDBWithSchemas("sqlite3", env.memoryDbConn(), true, false)
+	err = db.InitDBWithSchemas("sqlite3", env.memoryDbConn(), true, false, false)
 	if err != nil {
 		schema.ClearManager()
 		return fmt.Errorf("Failed to init DB: %s", err)

--- a/extension/gohanscript/gohanscript_suite_test.go
+++ b/extension/gohanscript/gohanscript_suite_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Suite set up and tear down", func() {
 		schemaFiles := config.GetStringList("schemas", nil)
 		Expect(schemaFiles).NotTo(BeNil())
 		Expect(manager.LoadSchemasFromFiles(schemaFiles...)).To(Succeed())
-		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false)).To(Succeed())
+		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false, false)).To(Succeed())
 	})
 
 	var _ = AfterSuite(func() {

--- a/extension/gohanscript/lib/gohan.go
+++ b/extension/gohanscript/lib/gohan.go
@@ -119,7 +119,7 @@ func ConnectDB(dbType string, connection string, maxOpenConn int) (db.DB, error)
 
 //InitDB initializes database using schema.
 func InitDB(dbType string, connection string, dropOnCreate bool, cascade bool) error {
-	err := db.InitDBWithSchemas(dbType, connection, dropOnCreate, cascade)
+	err := db.InitDBWithSchemas(dbType, connection, dropOnCreate, cascade, false)
 	return err
 }
 

--- a/extension/otto/otto_suite_test.go
+++ b/extension/otto/otto_suite_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Suite set up and tear down", func() {
 		schemaFiles := config.GetStringList("schemas", nil)
 		Expect(schemaFiles).NotTo(BeNil())
 		Expect(manager.LoadSchemasFromFiles(schemaFiles...)).To(Succeed())
-		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false)).To(Succeed())
+		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false, false)).To(Succeed())
 	})
 
 	var _ = AfterSuite(func() {

--- a/server/resources/resources_suite_test.go
+++ b/server/resources/resources_suite_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Suit set up and tear down", func() {
 		schemaFiles := config.GetStringList("schemas", nil)
 		Expect(schemaFiles).NotTo(BeNil())
 		Expect(manager.LoadSchemasFromFiles(schemaFiles...)).To(Succeed())
-		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false)).To(Succeed())
+		Expect(db.InitDBWithSchemas(dbType, dbFile, false, false, false)).To(Succeed())
 	})
 
 	var _ = AfterSuite(func() {

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,7 @@ func (server *Server) initDB() error {
 
 func (server *Server) connectDB() error {
 	config := util.GetConfig()
-	dbType, dbConnection, _, _ := server.getDatabaseConfig()
+	dbType, dbConnection, _, _, _ := server.getDatabaseConfig()
 	maxConn := config.GetInt("database/max_open_conn", db.DefaultMaxOpenConn)
 	dbConn, err := db.ConnectDB(dbType, dbConnection, maxConn)
 	if server.sync == nil {
@@ -147,7 +147,7 @@ func (server *Server) connectDB() error {
 	return err
 }
 
-func (server *Server) getDatabaseConfig() (string, string, bool, bool) {
+func (server *Server) getDatabaseConfig() (string, string, bool, bool, bool) {
 	config := util.GetConfig()
 	databaseType := config.GetString("database/type", "sqlite3")
 	if databaseType == "json" || databaseType == "yaml" {
@@ -159,7 +159,8 @@ func (server *Server) getDatabaseConfig() (string, string, bool, bool) {
 	}
 	databaseDropOnCreate := config.GetBool("database/drop_on_create", false)
 	databaseCascade := config.GetBool("database/cascade_delete", false)
-	return databaseType, databaseConnection, databaseDropOnCreate, databaseCascade
+	databaseAutoMigrate := config.GetBool("database/auto_migrate", true)
+	return databaseType, databaseConnection, databaseDropOnCreate, databaseCascade, databaseAutoMigrate
 }
 
 //NewServer returns new GohanAPIServer

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1307,7 +1307,7 @@ func initBenchmarkDatabase() error {
 	schema.ClearManager()
 	manager := schema.GetManager()
 	manager.LoadSchemasFromFiles("../tests/test_abstract_schema.yaml", "../tests/test_schema.yaml", "../etc/schema/gohan.json")
-	err := db.InitDBWithSchemas("mysql", "root@tcp(localhost:3306)/gohan_test", false, false)
+	err := db.InitDBWithSchemas("mysql", "root@tcp(localhost:3306)/gohan_test", false, false, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds `auto_migrate` flag (default true) that prevents from alter table on start, sample config snippet

    database:
        type: "mysql"
        auto_migrate: false
        connection: "gohan:gohan@/gohan_test"