### PR TITLE
cli: backup command

### DIFF
--- a/db/backup/backup.go
+++ b/db/backup/backup.go
@@ -1,0 +1,25 @@
+package backup
+
+import (
+	"io"
+	"fmt"
+)
+
+// Backup backups database to w.
+func Backup(dbType, dsn string, w io.Writer) error {
+	switch dbType {
+	case "mysql":
+		return doBackupMySQL(dsn, w)
+	default:
+		return fmt.Errorf("unsupported database type %q", dbType)
+	}
+}
+
+func doBackupMySQL(dsn string, w io.Writer) error {
+	config, err := NewMySQLConfig(dsn)
+	if err != nil {
+		return fmt.Errorf("Invalid connection string %q: %s", dsn, err)
+	}
+
+	return MySQL(config, w)
+}

--- a/db/backup/msyql.go
+++ b/db/backup/msyql.go
@@ -1,0 +1,86 @@
+package backup
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+
+	driver "github.com/go-sql-driver/mysql"
+)
+
+// MySQLConfig specifies mysql dump configuration, see the defaults.
+type MySQLConfig struct {
+	// DB Host (e.g. 127.0.0.1)
+	Host string
+	// DB Port (e.g. 3306)
+	Port string
+	// DB Name
+	DB string
+	// DB User
+	User string
+	// DB Password
+	Password string
+	// Extra mysqldump options
+	// e.g []string{"--extended-insert"}
+	Options []string
+}
+
+// NewMySQLConfig creates MySQLConfig based dsn data source connection string.
+func NewMySQLConfig(dsn string) (*MySQLConfig, error) {
+	c, err := driver.ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	host, port, _ := net.SplitHostPort(c.Addr)
+
+	return &MySQLConfig{
+		Host:     host,
+		Port:     port,
+		DB:       c.DBName,
+		User:     c.User,
+		Password: c.Passwd,
+	}, nil
+}
+
+// MysqlDumpCmd is the path to the `mysqldump` executable
+var MysqlDumpCmd = "mysqldump"
+
+// MySQLDefaultOptions specifies additional mysqldump flags.
+var MySQLDefaultOptions = []string{
+	"--protocol=TCP",
+	"--single-transaction",
+	"--add-drop-database",
+	"--hex-blob",
+	"--events",
+	"--routines",
+	"--triggers",
+}
+
+// MySQL dumps MySQL using mysqldump executable,
+func MySQL(config *MySQLConfig, w io.Writer) error {
+	if w == nil {
+		panic("Missing config")
+	}
+
+	args := mysqlOptions(config)
+	cmd := exec.Command(MysqlDumpCmd, args...)
+	cmd.Stdout = w
+
+	return cmd.Run()
+}
+
+func mysqlOptions(config *MySQLConfig) []string {
+	o := MySQLDefaultOptions
+	if config.Options != nil {
+		o = append(MySQLDefaultOptions, config.Options...)
+	}
+	o = append(o, fmt.Sprintf(`-h%v`, config.Host))
+	o = append(o, fmt.Sprintf(`-P%v`, config.Port))
+	o = append(o, fmt.Sprintf(`-u%v`, config.User))
+	o = append(o, fmt.Sprintf(`-p%v`, config.Password))
+	o = append(o, config.DB)
+
+	return o
+}

--- a/db/backup/mysql_test.go
+++ b/db/backup/mysql_test.go
@@ -1,0 +1,60 @@
+package backup
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewMySQLConfig(t *testing.T) {
+	data := []struct {
+		dsn      string
+		expected *MySQLConfig
+	}{
+		{
+			dsn: "user:password@/database",
+			expected: &MySQLConfig{
+				Host:     "127.0.0.1",
+				Port:     "3306",
+				DB:       "database",
+				User:     "user",
+				Password: "password",
+			},
+		},
+		{
+			dsn: "user:password@tcp(localhost:5555)/dbname?tls=skip-verify&autocommit=true",
+			expected: &MySQLConfig{
+				Host:     "localhost",
+				Port:     "5555",
+				DB:       "dbname",
+				User:     "user",
+				Password: "password",
+			},
+		},
+		{
+			dsn: "user:password@tcp([de:ad:be:ef::ca:fe]:80)/dbname?timeout=90s&collation=utf8mb4_unicode_ci",
+			expected: &MySQLConfig{
+				Host:     "de:ad:be:ef::ca:fe",
+				Port:     "80",
+				DB:       "dbname",
+				User:     "user",
+				Password: "password",
+			},
+		},
+		{
+			dsn: "id:password@broken/dbname",
+		},
+		{
+			dsn: "broken/dbname",
+		},
+	}
+
+	for _, tt := range data {
+		config, err := NewMySQLConfig(tt.dsn)
+		if err != nil {
+			t.Log("Unexpected error", tt, err)
+		}
+		if !reflect.DeepEqual(config, tt.expected) {
+			t.Error(tt, "got", config)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces backup capabilities to gohan. I'd thankful for advice how do we want this to be integrated with migrations. Do we want another flag like `dump_on_migrate`? IMHO dumping a database can be quite a surprising side effect of running a server. On the other hand the `migrate` command just generates SQL files.