### PR TITLE
Add resource permission

### DIFF
--- a/schema/policy.go
+++ b/schema/policy.go
@@ -23,9 +23,6 @@ import (
 )
 
 const (
-	conditionIsOwner       = "is_owner"
-	conditionTypeBelongsTo = "belongs_to"
-	conditionProperty      = "property"
 	// ActionGlob allows to perform all actions
 	ActionGlob = "*"
 	// ActionCreate allows to create a resource
@@ -37,12 +34,16 @@ const (
 	// ActionDelete allows to delete a resource
 	ActionDelete = "delete"
 
+	conditionIsOwner       = "is_owner"
+	conditionTypeBelongsTo = "belongs_to"
+	conditionProperty      = "property"
+
 	globalRegexp = ".*"
 
 	onlyOneOfTenantIDTenantNameError = "Only one of [tenant_id, tenant_name] should be specified"
 )
 
-var allActions = []string{ActionCreate, ActionRead, ActionUpdate, ActionDelete}
+var AllActions = []string{ActionCreate, ActionRead, ActionUpdate, ActionDelete}
 
 func newTenant(tenantID, tenantName string) Tenant {
 	tenantIDRegexp, _ := getRegexp(tenantID)
@@ -247,7 +248,7 @@ func (p *Policy) precomputeConditions() error {
 			conditionObject := condition.(map[string]interface{})
 			switch conditionObject["type"] {
 			case conditionTypeBelongsTo:
-				actions := allActions
+				actions := AllActions
 				if action, ok := conditionObject["action"]; ok && action != ActionGlob {
 					actions = []string{action.(string)}
 				}
@@ -271,7 +272,7 @@ func (p *Policy) precomputeConditions() error {
 					p.AddTenantToFilter(action, Tenant{ID: tenantID, Name: tenantName})
 				}
 			case conditionProperty:
-				actions := allActions
+				actions := AllActions
 				if action, ok := conditionObject["action"]; ok && action != ActionGlob {
 					actions = []string{action.(string)}
 				}

--- a/server/editor.go
+++ b/server/editor.go
@@ -46,6 +46,14 @@ func GetSchema(s *schema.Schema, authorization schema.Authorization) (result *sc
 	filteredSchema["propertiesOrder"] = schemaPropertiesOrder
 	filteredSchema["required"] = schemaRequired
 
+	permission := []string{}
+	for _, a := range schema.AllActions {
+		if p, _ := manager.PolicyValidate(a, s.GetPluralURL(), authorization); p != nil {
+			permission = append(permission, a)
+		}
+	}
+	filteredSchema["permission"] = permission
+
 	result, err = schema.NewResource(metaschema, rawSchema)
 	if err != nil {
 		log.Warning("%s %s", result, err)

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -186,6 +186,11 @@ var _ = Describe("Resource manager", func() {
 				Expect(ok).To(BeFalse())
 				_, ok = properties["shared"]
 				Expect(ok).To(BeFalse())
+
+				By("Adding schema permission")
+				permission, ok := theSchema["permission"].([]string)
+				Expect(ok).To(BeTrue())
+				Expect(permission).To(Equal([]string{"create", "read", "update", "delete"}))
 			})
 
 			It("Should return no schema when appropriate", func() {


### PR DESCRIPTION
This PR modifies `GetSchema` to extend resource with `permission` field listing resource effective permissions.

Sample output for UI

```json
{
  "schemas": [
    {
      ...
      "schema": {
        "permission": [
          "read"
        ],
        "properties": {
           ...
```