### PR TITLE
ESI-11160 cleanup transactions after finishing extensions

### DIFF
--- a/extension/otto/gohan_core.go
+++ b/extension/otto/gohan_core.go
@@ -17,6 +17,7 @@ package otto
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -81,6 +82,7 @@ func init() {
 				value, _ := vm.ToValue(response)
 				return value
 			},
+			"gohan_closers": []io.Closer{},
 		}
 
 		for name, object := range builtins {

--- a/extension/otto/gohan_db.go
+++ b/extension/otto/gohan_db.go
@@ -47,6 +47,13 @@ func init() {
 				if err != nil {
 					ThrowOttoException(&call, "failed to start a transaction: %s", err.Error())
 				}
+
+				if err = addCloser(call.Otto, tx); err != nil {
+					tx.Close()
+					ThrowOttoException(&call, fmt.Errorf(
+						"Cannot register closer for gohan_db_transaction: %s", err).Error())
+				}
+
 				if setTxIsolationLevel {
 					strIsolationLevel, err := GetString(call.Argument(0))
 					if err != nil {


### PR DESCRIPTION
Due to developer mistakes or VM interruption it is possible that
Created transactions were not cleaned up after VM finished execution.
This was most nagging for long running extensions, that could be
interrupted at any time due to client disconnection or timeout.
Unfortunately, Otto runtime doesn't provide a way to interrupt
execution (like generating exception) and allowing custom code
to execute finally clauses.

In this commit, we maintain []io.Closer of objects stored in global
variable of VM "gohan_closers".

Buitlins (currently only gohan_db_transaction) can expand this list
with object, that we need to ensure that are properly closed.

Upon VM exit, regardless if it was successful or resulted in error,
Gohan goes through that list and calls Close. This requires from
stored Closer object to allow multiple Close calls.

Provide additional logging for transaction tracking