### PR TITLE
Revert "[ESI-10454] Handling nullable attributes in update and create…

### DIFF
--- a/extension/framework/runner/test_data/extension1.js
+++ b/extension/framework/runner/test_data/extension1.js
@@ -35,17 +35,17 @@ gohan_register_handler("custom_action", function (context) {
   var new_network = {
     "id": context.id,
     "name": "Net1",
-    "status": "ACTIVE",
-    "shared": false,
-    "admin_state_up": true
+    "status": "ACTIVE"
   };
   gohan_db_create(tx, "network", new_network);
   tx.Commit();
   tx.Close();
 
   tx = gohan_db_transaction();
-  new_network.name = "Net2";
-  new_network.status = "DOWN";
+  var new_network = {
+    "id": context.id,
+    "status": "DOWN"
+  };
   gohan_db_update(tx, "network", new_network);
   tx.Commit();
   tx.Close();

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -733,19 +733,18 @@ var _ = Describe("Otto extension manager", func() {
 						"id": "test_extension",
 						"code": `
 						gohan_register_handler("test_event", function(context){
-						  var network = {
-						    'id':'test1',
-						    'name': 'name',
-						    'description': 'description',
-						    'providor_networks': {},
-						    'route_targets': [],
-						    'shared': false,
-						    'tenant_id': 'admin'
-						  };
-						  gohan_db_create(context.transaction, 'network', network);
+						  gohan_db_create(context.transaction,
+						    'network', {
+								'id':'test1',
+								'name': 'name',
+								'description': 'description',
+								'providor_networks': {},
+								'route_targets': [],
+								'shared': false,
+								'tenant_id': 'admin'});
 						  context.network = gohan_db_fetch(context.transaction, 'network', 'test1', 'admin');
-						  network.name = "name_updated";
-						  gohan_db_update(context.transaction, 'network', network);
+						  gohan_db_update(context.transaction,
+						    'network', {'id':'test1', 'name': 'name_updated', 'tenant_id': 'admin'});
 						  context.networks = gohan_db_list(context.transaction, 'network', {});
 						  context.networks2 = gohan_db_list(context.transaction, 'network', {'shared': false});
 						  gohan_db_delete(context.transaction, 'network', 'test1');
@@ -779,19 +778,18 @@ var _ = Describe("Otto extension manager", func() {
 						"id": "test_extension",
 						"code": `
 						gohan_register_handler("test_event", function(context){
-						  var network = {
-						    'id':'test1',
-						    'name': 'name',
-						    'description': 'description',
-						    'providor_networks': {},
-						    'route_targets': [],
-						    'shared': false,
-						    'tenant_id': 'admin'
-						  };
-						  gohan_db_create(context.transaction, 'network', network);
+						  gohan_db_create(context.transaction,
+						    'network', {
+								'id':'test1',
+								'name': 'name',
+								'description': 'description',
+								'providor_networks': {},
+								'route_targets': [],
+								'shared': false,
+								'tenant_id': 'admin'});
 						  context.network = gohan_db_fetch(context.transaction, 'network', 'test1', 'admin');
-						  network.name = "name_updated";
-						  gohan_db_update(context.transaction, 'network', network);
+						  gohan_db_update(context.transaction,
+						    'network', {'id':'test1', 'name': 'name_updated', 'tenant_id': 'admin'});
 						  context.networks = gohan_db_list(context.transaction, 'network', {});
 						  gohan_db_delete(context.transaction, 'network', 'test1');
 						  context.networks2 = gohan_db_list(context.transaction, 'network', {});
@@ -827,18 +825,18 @@ var _ = Describe("Otto extension manager", func() {
 						"code": `
 						gohan_register_handler("test_event", function(context){
 						  var tx = gohan_db_transaction();
-						  var network = {
-						    'id':'test1',
-						    'name': 'name',
-						    'description': 'description',
-						    'providor_networks': {},
-						    'route_targets': [],
-						    'shared': false,
-						    'tenant_id': 'admin'
-						  };
-						  gohan_db_create(tx, 'network', network);
+						  gohan_db_create(tx,
+						    'network', {
+								'id':'test1',
+								'name': 'name',
+								'description': 'description',
+								'providor_networks': {},
+								'route_targets': [],
+								'shared': false,
+								'tenant_id': 'admin'});
 						  context.network = gohan_db_fetch(tx, 'network', 'test1', 'admin');
-						  gohan_db_update(tx, 'network', network);
+						  gohan_db_update(tx,
+						    'network', {'id':'test1', 'name': 'name_updated', 'tenant_id': 'admin'});
 						  context.networks = gohan_db_list(tx, 'network', {});
 						  gohan_db_delete(tx, 'network', 'test1');
 						  context.networks2 = gohan_db_list(tx, 'network', {});

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -340,8 +340,6 @@ schemas:
     propertiesOrder:
     - id
     - tenant_id
-    required:
-    - tenant_id
     type: object
   singular: test
   title: Test


### PR DESCRIPTION
… queries"

This reverts commit 9b06b813dc41e2457e3c05edb5bf55d564838ef7.

This commit makes unspecified column as null value, thus this commit
makes update api call backward incompatible.
We should specify null attribute explicitly.