### PR TITLE
Workaround for a goose bug

### DIFF
--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -62,18 +62,23 @@ func Init() error {
 	dbType, dbConnection, migrationsPath := readGooseConfig()
 
 	if err := goose.SetDialect(dbType); err != nil {
-		fmt.Printf("error: failed to set goose dialect: %s\n", err.Error())
-		return err
+		return fmt.Errorf("migration: failed to set goose dialect: %s", err)
 	}
 
 	db, err := sql.Open(dbType, dbConnection)
 
 	if err != nil {
-		fmt.Printf("error: failed to open db: %s\n", err.Error())
-		return err
+		return fmt.Errorf("migration: failed to open db: %s", err)
 	}
 
-	return goose.Status(db, migrationsPath)
+	v, err := goose.EnsureDBVersion(db)
+	if err != nil {
+		return fmt.Errorf("migration: failed to ensure db version: %s", err)
+	}
+
+	logger.Info("migration path: %q, version: %d", migrationsPath, v)
+
+	return nil
 }
 
 func Help() {


### PR DESCRIPTION
This is a workaround for a bug in goose, resulting in 

```2017/03/14 10:24:00 sql: Scan error on column index 0: unsupported Scan, storing driver.Value type []uint8 into type *time.Time```

on start.
