### PR TITLE
Added tags to openapi documentation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,8 @@ GLOBAL OPTIONS:
     OPTIONS:
         --config-file "gohan.yaml"				Server config File
         --template, -t "embed://etc/templates/openapi.tmpl"	Template File
+        --split-by-resource-group ""                           Group by resource
+        --policy "admin"                                       Show only schema with chosen policy
 ```
 
 ## MarkDown
@@ -100,6 +102,8 @@ GLOBAL OPTIONS:
     OPTIONS:
         --config-file "gohan.yaml"				Server config File
         --template, -t "embed://etc/templates/markdown.tmpl"	Template File
+        --split-by-resource-group ""                           Group by resource
+        --policy "admin"                                       Show only schema with chosen policy
 ```
 
 ## CLI Client

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -157,6 +157,11 @@ We don't sync this resource for sync backend when this option is true.
 
   Write only the value of the specified property to the sync backend.
 
+- resource_group (string)
+
+  Used in OpenApi documentation it allows to categorized schema according to given `resource_group` by setting appropriate tags.
+  If `--split-by-resource-group` option is used to generate OpenApi documentation it will additionally place given schema to `resource_group.js` file.
+
 ## Properties
 
 We need to define properties of a resource using following parameters.

--- a/etc/templates/openapi.tmpl
+++ b/etc/templates/openapi.tmpl
@@ -20,7 +20,10 @@
                 "description" : "Get list of {{ schema.ID}} resources",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "responses": {
                     "200": {
                         "description": "{{ schema.description }}",
@@ -45,7 +48,10 @@
                 "description" : "Show a {{ schema.ID}} resources",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "parameters": [
                 {
                     "name": "id",
@@ -76,7 +82,10 @@
                 "description": "{% if action.Description | length == 0 %}Action {{ action.ID}}{% else %}{{ action.Description }}{% endif %}",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 {% with has_id=action.Path | swagger_has_id_param put_or_post=action.Method | lower == "post" or action.Method | lower == "put" %}
                 {% with has_params_in_get=action.Method | lower == "get" and action.Parameters | length != 0 %}
                 "parameters": [ {% if has_id %}
@@ -128,7 +137,10 @@
                 "description" : "Get list of {{ schema.ID}} resources",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "responses": {
                     "200": {
                         "description": "{{ schema.description }}",
@@ -151,7 +163,10 @@
                 "description" : "Create new {{ schema.ID }} resource",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "parameters": [
                 {
                     "name": "{{ schema.ID }}",
@@ -183,7 +198,10 @@
                 "description" : "Show a {{ schema.ID}} resources",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "parameters": [
                 {
                     "name": "id",
@@ -212,7 +230,10 @@
                 "description" : "Update {{ schema.ID }} resource",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "parameters": [
                 {
                     "name": "id",
@@ -249,7 +270,10 @@
                 "description" : "Delete a {{ schema.ID }} resources",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 "parameters": [
                 {
                     "name": "id",
@@ -280,7 +304,10 @@
                 "description": "{% if action.Description | length == 0 %}Action {{ action.ID}}{% else %}{{ action.Description }}{% endif %}",
                 "produces": [
                     "application/json"
-                ],
+                ],{% if schema.Metadata.resource_group | length != 0 %}
+                "tags": [
+                    "{{ schema.Metadata.resource_group }}"
+                ],{% endif %}
                 {% with has_id=action.Path | swagger_has_id_param put_or_post=action.Method | lower == "post" or action.Method | lower == "put" %}
                 {% with has_params_in_get=action.Method | lower == "get" and action.Parameters | length != 0 %}
                 "parameters": [ {% if has_id %}


### PR DESCRIPTION
This will add tags based on resource_group field.

Have a question about this commit:
As you see now it's turn on by default - should I add some flag to enable it only when the flag is given?
And probably split-by-resource will now be redundant as this option allows to create categories in a single json file.