### PR TITLE
Add builtin gohan_sync_delete for JS extension

### DIFF
--- a/docs/js_extension.md
+++ b/docs/js_extension.md
@@ -295,6 +295,15 @@ Check if dir
 
 Fetch a given path from Sync   
 
+- gohan_sync_delete(path, prefix)
+
+Delete a given path from Sync. If prefix is given as ``true``, all paths which starts
+with ``path`` are deleted.
+path : sync path to be deleted
+prefix (optional) : boolean - whether to delete paths which starts with ``path``.
+This option is applied if gohan uses etcd v3 for sync. If gohan uses etcd v2, this option
+is translated as ``--recursive``
+
 - gohan_sync_watch(path, timeout, revision)
 
 Watch a given path in Sync starting from a given revision. This call is blocking no longer

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -222,6 +222,7 @@ func (env *Environment) addTestingAPI() {
 	env.mockFunction("gohan_exec")
 	env.mockFunction("gohan_config")
 	env.mockFunction("gohan_sync_fetch")
+	env.mockFunction("gohan_sync_delete")
 	env.mockFunction("gohan_sync_watch")
 }
 

--- a/server/sync.go
+++ b/server/sync.go
@@ -178,17 +178,17 @@ func (server *Server) syncEvent(resource *schema.Resource) error {
 			}
 		}
 		log.Debug("deleting %s", statePrefix+deletePath)
-		err = server.sync.Delete(statePrefix + deletePath)
+		err = server.sync.Delete(statePrefix + deletePath, false)
 		if err != nil {
 			log.Error(fmt.Sprintf("Delete from sync failed %s", err))
 		}
 		log.Debug("deleting %s", monitoringPrefix+deletePath)
-		err = server.sync.Delete(monitoringPrefix + deletePath)
+		err = server.sync.Delete(monitoringPrefix + deletePath, false)
 		if err != nil {
 			log.Error(fmt.Sprintf("Delete from sync failed %s", err))
 		}
 		log.Debug("deleting %s", resourcePath)
-		err = server.sync.Delete(path)
+		err = server.sync.Delete(path, false)
 		if err != nil {
 			log.Error(fmt.Sprintf("Delete from sync failed %s", err))
 			return err

--- a/sync/etcd/etcd.go
+++ b/sync/etcd/etcd.go
@@ -61,8 +61,11 @@ func (s *Sync) Update(key, jsonString string) error {
 }
 
 //Delete sync update sync
-func (s *Sync) Delete(key string) error {
-	s.etcdClient.Delete(key, false)
+func (s *Sync) Delete(key string, prefix bool) error {
+	if prefix {
+		log.Warning("Prefix option is translated as Recursive for Etcd v2 compatibility.")
+	}
+	s.etcdClient.Delete(key, prefix)
 	return nil
 }
 

--- a/sync/etcdv3/etcd.go
+++ b/sync/etcdv3/etcd.go
@@ -87,8 +87,12 @@ func (s *Sync) Update(key, jsonString string) error {
 }
 
 //Delete sync update sync
-func (s *Sync) Delete(key string) error {
-	_, err := s.etcdClient.Delete(s.withTimeout(), key)
+func (s *Sync) Delete(key string, prefix bool) error {
+	opts := []etcd.OpOption{}
+	if prefix {
+		opts = append(opts, etcd.WithPrefix())
+	}
+	_, err := s.etcdClient.Delete(s.withTimeout(), key, opts...)
 	return err
 }
 

--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -46,7 +46,7 @@ func TestNonEmptyUpdate(t *testing.T) {
 		t.Errorf("unexpected node: %+v", node)
 	}
 
-	err = sync.Delete(path)
+	err = sync.Delete(path, false)
 	if err != nil {
 		t.Errorf("unexpected error")
 	}

--- a/sync/noop/noop.go
+++ b/sync/noop/noop.go
@@ -32,7 +32,7 @@ func (sync *Sync) Update(path, json string) error {
 }
 
 //Delete sync update sync
-func (sync *Sync) Delete(path string) error {
+func (sync *Sync) Delete(path string, prefix bool) error {
 	return nil
 }
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -24,7 +24,7 @@ type Sync interface {
 	Unlock(path string) error
 	Fetch(path string) (*Node, error)
 	Update(path, json string) error
-	Delete(path string) error
+	Delete(path string, prefix bool) error
 	Watch(path string, responseChan chan *Event, stopChan chan bool, revision int64) error
 	Close()
 }


### PR DESCRIPTION
Usecase: With configuration watch/keys list, gohan can run some events
  reported from southbound resources. However, this is not a sync_key of
  gohan resources, so gohan does not have a way to delete watching etcd
  pathes. These garbages will occur worse performance, and if gohan
  restarted for some reason, a lot of unnecessary events might happen
  due to remaining sync pathes. Of course, cleanup of sync pathes can be
  done from outside of gohan, but this new builtin lets gohan manage
  sync pathes efficiently based on gohan's internal status.

  This builtin can delete multiple pathes based on prefix if etcd v3 is
  used for sync. This should be also convenient for this kind of cleanup
  feature.