### PR TITLE
[ESI-10997] emit 'exit' event on test exit. gohan_load_hook and gohan_get_env hook...

### DIFF
--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -78,12 +78,7 @@ func (env *Environment) InitializeEnvironment() error {
 	env.SetUp()
 	env.addTestingAPI()
 
-	script, err := env.VM.Otto.Compile(env.testFileName, env.testSource)
-	if err != nil {
-		return fmt.Errorf("Failed to compile the file '%s': %s", env.testFileName, err)
-	}
-
-	env.VM.Otto.Run(script)
+	env.Load(env.testFileName, string(env.testSource))
 
 	err = env.loadSchemaIncludes()
 

--- a/extension/framework/runner/runner.go
+++ b/extension/framework/runner/runner.go
@@ -25,6 +25,8 @@ import (
 	"github.com/xyproto/otto/ast"
 	"github.com/xyproto/otto/parser"
 
+	"time"
+
 	l "github.com/cloudwan/gohan/log"
 )
 
@@ -160,6 +162,10 @@ func (runner *TestRunner) runTest(testName string, env *Environment) (err error)
 			err = fmt.Errorf(ottoError.String())
 		}
 	}
+
+	env.SetEventTimeLimit("exit", time.Second*30)
+	env.HandleEvent("exit", map[string]interface{}{})
+
 	mockError := env.CheckAllMockCallsMade()
 	if err == nil {
 		err = mockError

--- a/extension/otto/gohan_core.go
+++ b/extension/otto/gohan_core.go
@@ -90,6 +90,7 @@ func init() {
 		}
 
 		loadNPMModules()
+		registerBuiltinModules(vm)
 
 		err := env.Load("<Gohan built-in exceptions>", `
 		function BaseException() {
@@ -262,4 +263,19 @@ func loadNPMModules() {
 			motto.AddModule(f.Name(), loader)
 		}
 	}
+}
+
+func registerBuiltinModules(vm *motto.Motto) {
+	vm.AddModule("fs", fsModule)
+	vm.AddModule("vm", vmModule)
+	vm.AddModule("crypto", cryptoModule)
+
+	vm.AddModule("os", emptyModule)
+	vm.AddModule("assert", emptyModule)
+	vm.AddModule("glob", emptyModule)
+}
+
+func emptyModule(vm *motto.Motto) (otto.Value, error) {
+	module, _ := vm.Object(`({})`)
+	return vm.ToValue(module)
 }

--- a/extension/otto/gohan_crypto.go
+++ b/extension/otto/gohan_crypto.go
@@ -1,0 +1,69 @@
+package otto
+
+import (
+	"crypto/md5"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"io"
+
+	"github.com/ddliu/motto"
+	"github.com/robertkrimen/otto"
+)
+
+func cryptoModule(vm *motto.Motto) (otto.Value, error) {
+	mod, _ := vm.Object(`({})`)
+
+	mod.Set("createHash", func(call otto.FunctionCall) otto.Value {
+		VerifyCallArguments(&call, "createHash", 1)
+		_, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Algorithm: %v", err)
+
+		return wrapHash(md5.New(), vm)
+	})
+
+	return vm.ToValue(mod)
+}
+
+func wrapHash(h hash.Hash, vm *motto.Motto) otto.Value {
+	wrapped, _ := vm.Object(`({})`)
+
+	wrapped.Set("update", func(call otto.FunctionCall) otto.Value {
+		data, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Data: %v", err)
+
+		_, err = io.WriteString(h, data)
+		ThrowWithMessageIfHappened(&call, err,
+			"Failed to update hash with data: %v", err)
+
+		v, _ := vm.ToValue(wrapped)
+		return v
+	})
+
+	wrapped.Set("digest", func(call otto.FunctionCall) otto.Value {
+		encoding, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Encoding: %v", err)
+
+		sum := h.Sum(nil)
+
+		var result string
+		switch encoding {
+		case "base64":
+			result = base64.StdEncoding.EncodeToString(sum)
+		case "hex":
+			result = fmt.Sprintf("%x", sum)
+		default:
+			ThrowOttoException(&call,
+				"Unsupported hash encoding: '%s'", encoding)
+		}
+
+		v, _ := vm.ToValue(result)
+		return v
+	})
+
+	v, _ := vm.ToValue(wrapped)
+	return v
+}

--- a/extension/otto/gohan_crypto.go
+++ b/extension/otto/gohan_crypto.go
@@ -8,7 +8,7 @@ import (
 	"io"
 
 	"github.com/ddliu/motto"
-	"github.com/robertkrimen/otto"
+	"github.com/xyproto/otto"
 )
 
 func cryptoModule(vm *motto.Motto) (otto.Value, error) {

--- a/extension/otto/gohan_fs.go
+++ b/extension/otto/gohan_fs.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2016 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otto
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/ddliu/motto"
+	"github.com/robertkrimen/otto"
+)
+
+func fsModule(vm *motto.Motto) (otto.Value, error) {
+	fs, _ := vm.Object(`({})`)
+
+	// Modified from motto documentation
+	fs.Set("readFileSync", func(call otto.FunctionCall) otto.Value {
+		filename, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Filename: %v", err)
+
+		bytes, err := ioutil.ReadFile(filename)
+		ThrowWithMessageIfHappened(&call, err,
+			"Failed to read file '%s': %v", filename, err)
+
+		// Note: according to the specification,
+		// we should return a Buffer instead
+		// if the 'encoding' argument isn't provided.
+		// But we always return a string here.
+		v, _ := call.Otto.ToValue(string(bytes))
+		return v
+	})
+
+	fs.Set("existsSync", func(call otto.FunctionCall) otto.Value {
+		filename, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Filename: %v", err)
+
+		_, err = os.Stat(filename)
+
+		v, _ := call.Otto.ToValue(err == nil)
+		return v
+	})
+
+	fs.Set("writeFileSync", func(call otto.FunctionCall) otto.Value {
+		filename, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Filename: %v", err)
+		data, err := GetString(call.Argument(1))
+		ThrowWithMessageIfHappened(&call, err,
+			"File data: %v", err)
+
+		err = ioutil.WriteFile(filename, []byte(data), 0666)
+		ThrowWithMessageIfHappened(&call, err,
+			"Failed to write file '%s': %v", filename, err)
+		return otto.UndefinedValue()
+	})
+
+	fs.Set("readdirSync", func(call otto.FunctionCall) otto.Value {
+		dirname, err := GetString(call.Argument(0))
+		ThrowIfHappened(&call, err)
+
+		files, err := ioutil.ReadDir(dirname)
+		ThrowIfHappened(&call, err)
+
+		var result []string
+		for _, file := range files {
+			result = append(result, file.Name())
+		}
+
+		v, _ := call.Otto.ToValue(result)
+		return v
+	})
+
+	fs.Set("mkdirSync", func(call otto.FunctionCall) otto.Value {
+		if len(call.ArgumentList) < 2 {
+			defaultMode, _ := otto.ToValue(0777)
+			call.ArgumentList = append(call.ArgumentList, defaultMode)
+		}
+		VerifyCallArguments(&call, "mkdirSync", 2)
+		dirname, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Directory name: %v", err)
+		mode, err := GetInt64(call.Argument(1))
+		ThrowWithMessageIfHappened(&call, err,
+			"Permission mode: %v", err)
+
+		// TODO properly handle "file exists" error instead
+		err = os.MkdirAll(dirname, os.FileMode(int32(mode)))
+		ThrowWithMessageIfHappened(&call, err,
+			"Failed to create directory '%s': %v", dirname, err)
+
+		return otto.UndefinedValue()
+	})
+
+	return vm.ToValue(fs)
+}

--- a/extension/otto/gohan_fs.go
+++ b/extension/otto/gohan_fs.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/ddliu/motto"
-	"github.com/robertkrimen/otto"
+	"github.com/xyproto/otto"
 )
 
 func fsModule(vm *motto.Motto) (otto.Value, error) {

--- a/extension/otto/gohan_hook.go
+++ b/extension/otto/gohan_hook.go
@@ -1,0 +1,28 @@
+package otto
+
+import (
+	"github.com/xyproto/otto"
+)
+
+func init() {
+	gohanHookInit := func(env *Environment) {
+		vm := env.VM
+		builtins := map[string]interface{}{
+			"gohan_load_hook": func(call otto.FunctionCall) otto.Value {
+				VerifyCallArguments(&call, "gohan_load_hook", 1)
+				funcName, err := GetString(call.Argument(0))
+				if err != nil {
+					ThrowOttoException(&call, err.Error())
+				}
+				env.loadHooks = append(env.loadHooks, funcName)
+				return otto.TrueValue()
+			},
+		}
+
+		for name, object := range builtins {
+			vm.Set(name, object)
+		}
+
+	}
+	RegisterInit(gohanHookInit)
+}

--- a/extension/otto/gohan_util.go
+++ b/extension/otto/gohan_util.go
@@ -31,9 +31,11 @@ import (
 	"github.com/xyproto/otto"
 	"github.com/twinj/uuid"
 
+	"os"
+	"strings"
+
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
-	"strings"
 )
 
 const (
@@ -323,6 +325,19 @@ func init() {
 				}
 				config := util.GetConfig()
 				result := config.GetParam(configKey, defaultValue)
+				value, _ := vm.ToValue(result)
+				return value
+			},
+			"gohan_get_env": func(call otto.FunctionCall) otto.Value {
+				VerifyCallArguments(&call, "gohan_get_env", 2)
+				key, err := GetString(call.Argument(0))
+				ThrowWithMessageIfHappened(&call, err, "Expected one string argument")
+				defaultValue, err := GetString(call.Argument(1))
+				ThrowWithMessageIfHappened(&call, err, "Expected default value")
+				result := os.Getenv(key)
+				if result == "" {
+					result = defaultValue
+				}
 				value, _ := vm.ToValue(result)
 				return value
 			},

--- a/extension/otto/gohan_vm.go
+++ b/extension/otto/gohan_vm.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otto
+
+import (
+	"github.com/ddliu/motto"
+	"github.com/robertkrimen/otto"
+)
+
+func vmModule(vm *motto.Motto) (otto.Value, error) {
+	mod, _ := vm.Object(`({})`)
+
+	emptyFunctions := []string{
+		"createScript",
+	}
+	for _, funName := range emptyFunctions {
+		mod.Set(funName, func(call otto.FunctionCall) otto.Value {
+			return otto.UndefinedValue()
+		})
+	}
+
+	mod.Set("runInThisContext", func(call otto.FunctionCall) otto.Value {
+		VerifyCallArguments(&call, "runInThisContext", 2)
+		source, err := GetString(call.Argument(0))
+		ThrowWithMessageIfHappened(&call, err,
+			"Source code: %v", err)
+		filename, err := GetString(call.Argument(1))
+		ThrowWithMessageIfHappened(&call, err,
+			"Filename: %v", err)
+
+		script, err := vm.Compile(filename, source)
+		ThrowWithMessageIfHappened(&call, err,
+			"Failed to compile %s err: %v", filename, err)
+		result, err := vm.Otto.Run(script)
+		ThrowIfHappened(&call, err)
+		v, _ := vm.ToValue(result)
+		return v
+	})
+
+	return vm.ToValue(mod)
+}

--- a/extension/otto/gohan_vm.go
+++ b/extension/otto/gohan_vm.go
@@ -17,7 +17,7 @@ package otto
 
 import (
 	"github.com/ddliu/motto"
-	"github.com/robertkrimen/otto"
+	"github.com/xyproto/otto"
 )
 
 func vmModule(vm *motto.Motto) (otto.Value, error) {

--- a/vendor/github.com/ddliu/motto/README.md
+++ b/vendor/github.com/ddliu/motto/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/ddliu/motto.png)](https://travis-ci.org/ddliu/motto)
 
-Modular [otto](https://github.com/robertkrimen/otto)
+Modular [otto](https://github.com/xyproto/otto)
 
 Motto provide a Nodejs like module environment to run javascript files in golang.
 
@@ -55,7 +55,7 @@ package fs
 
 import (
     "github.com/ddliu/motto"
-    "github.com/robertkrimen/otto"
+    "github.com/xyproto/otto"
 )
 
 func fsModuleLoader(vm *motto.Motto) (otto.Value, error) {

--- a/vendor/github.com/ddliu/motto/underscore/underscore.go
+++ b/vendor/github.com/ddliu/motto/underscore/underscore.go
@@ -6,7 +6,7 @@ package underscore
 
 import (
 	"github.com/ddliu/motto"
-	"github.com/xyproto/otto"
+	"github.com/robertkrimen/otto"
 )
 
 func underscore(vm *motto.Motto) (otto.Value, error) {


### PR DESCRIPTION
This PR contain few changes:

- Basic functionality of `crypto`, `fs`, `vm` modules from Node.js
- Update of ddliu/motto to current master
- emiting 'exit' event on extension test end - this can be used for gathering some runtime test results such as coverage, profiling
- gohan_load_hook builtin - ability to register hook for code loading. This can be for instrumenting code with coverage flags, profiler flags. It's implemented as "don't pay if you don't use it' manner. 
- gohan_get_env builtin - retrieving environmental variable from extension code
- removed "file://" prefix from paths passed to vm.Load()

We use these changes for code coverage together with `istanbul` library.