### PR TITLE
ESI-11829 Allow locking resorces in pre update/create

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Database operation test", func() {
 				})
 
 				It("Locks the expected list", func() {
-					list, num, err := tx.LockList(networkSchema, nil, nil, transaction.LockRelatedResources)
+					list, num, err := tx.LockList(networkSchema, nil, nil, schema.LockRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(2)))
 					Expect(list).To(HaveLen(2))
@@ -207,7 +207,7 @@ var _ = Describe("Database operation test", func() {
 					filter := map[string]interface{}{
 						"tenant_id": []string{"red"},
 					}
-					list, num, err := tx.LockList(networkSchema, filter, nil, transaction.LockRelatedResources)
+					list, num, err := tx.LockList(networkSchema, filter, nil, schema.LockRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(1)))
 					Expect(list).To(HaveLen(1))
@@ -227,7 +227,7 @@ var _ = Describe("Database operation test", func() {
 					filter := map[string]interface{}{
 						"bad_filter": []string{"red"},
 					}
-					_, _, err := tx.LockList(networkSchema, filter, nil, transaction.LockRelatedResources)
+					_, _, err := tx.LockList(networkSchema, filter, nil, schema.LockRelatedResources)
 					Expect(err).To(HaveOccurred())
 				})
 
@@ -241,7 +241,7 @@ var _ = Describe("Database operation test", func() {
 				})
 
 				It("Locks related resources when requested", func() {
-					list, num, err := tx.LockList(serverSchema, nil, nil, transaction.LockRelatedResources)
+					list, num, err := tx.LockList(serverSchema, nil, nil, schema.LockRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(1)))
 					Expect(list).To(HaveLen(1))
@@ -250,7 +250,7 @@ var _ = Describe("Database operation test", func() {
 				})
 
 				It("Doesn't lock related resources when requested", func() {
-					list, num, err := tx.LockList(serverSchema, nil, nil, transaction.SkipRelatedResources)
+					list, num, err := tx.LockList(serverSchema, nil, nil, schema.SkipRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(1)))
 					Expect(list).To(HaveLen(1))
@@ -266,21 +266,21 @@ var _ = Describe("Database operation test", func() {
 				})
 
 				It("Fetches and locks an existing resource", func() {
-					networkResourceFetched, err := tx.LockFetch(networkSchema, transaction.IDFilter(networkResource1.ID()), transaction.LockRelatedResources)
+					networkResourceFetched, err := tx.LockFetch(networkSchema, transaction.IDFilter(networkResource1.ID()), schema.LockRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(networkResourceFetched).To(util.MatchAsJSON(networkResource1))
 					Expect(tx.Commit()).To(Succeed())
 				})
 
 				It("Fetches and locks related resources when requested", func() {
-					networkResourceFetched, err := tx.LockFetch(serverSchema, nil, transaction.LockRelatedResources)
+					networkResourceFetched, err := tx.LockFetch(serverSchema, nil, schema.LockRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(networkResourceFetched.Data()).To(HaveKeyWithValue("network", HaveKeyWithValue("name", networkResource1.Data()["name"])))
 					Expect(tx.Commit()).To(Succeed())
 				})
 
 				It("Fetches and doesn't lock related resources when requested", func() {
-					networkResourceFetched, err := tx.LockFetch(serverSchema, nil, transaction.SkipRelatedResources)
+					networkResourceFetched, err := tx.LockFetch(serverSchema, nil, schema.SkipRelatedResources)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(networkResourceFetched.Data()).To(HaveKeyWithValue("network", HaveKeyWithValue("name", BeNil())))
 					Expect(tx.Commit()).To(Succeed())

--- a/db/file/file.go
+++ b/db/file/file.go
@@ -269,7 +269,7 @@ func (tx *Transaction) List(s *schema.Schema, filter transaction.Filter, pg *pag
 }
 
 //Lock resources in the db. Not supported in file db
-func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, pg *pagination.Paginator, policy transaction.LockPolicy) (list []*schema.Resource, total uint64, err error) {
+func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, pg *pagination.Paginator, policy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
 	return tx.List(s, filter, pg)
 }
 
@@ -283,7 +283,7 @@ func (tx *Transaction) Fetch(s *schema.Schema, filter transaction.Filter) (*sche
 }
 
 //Fetch & lock a resource. Not supported in file db
-func (tx *Transaction) LockFetch(s *schema.Schema, filter transaction.Filter, policy transaction.LockPolicy) (*schema.Resource, error) {
+func (tx *Transaction) LockFetch(s *schema.Schema, filter transaction.Filter, policy schema.LockPolicy) (*schema.Resource, error) {
 	return tx.Fetch(s, filter)
 }
 

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -751,11 +751,11 @@ func (tx *Transaction) List(s *schema.Schema, filter transaction.Filter, pg *pag
 	return executeSelect(s, filter, sql, args, tx)
 }
 
-func shouldJoin(policy transaction.LockPolicy) bool {
+func shouldJoin(policy schema.LockPolicy) bool {
 	switch policy {
-	case transaction.LockRelatedResources:
+	case schema.LockRelatedResources:
 		return true
-	case transaction.SkipRelatedResources:
+	case schema.SkipRelatedResources:
 		return false
 	default:
 		log.Fatalf("Unknown lock policy %+v", policy)
@@ -764,7 +764,7 @@ func shouldJoin(policy transaction.LockPolicy) bool {
 }
 
 //Lock resources in the db
-func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, pg *pagination.Paginator, lockPolicy transaction.LockPolicy) (list []*schema.Resource, total uint64, err error) {
+func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, pg *pagination.Paginator, lockPolicy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
 	sql, args, err := buildSelect(s, filter, pg, shouldJoin(lockPolicy))
 	if err != nil {
 		return nil, 0, err
@@ -846,7 +846,7 @@ func (tx *Transaction) Fetch(s *schema.Schema, filter transaction.Filter) (*sche
 }
 
 //Fetch & lock a resource
-func (tx *Transaction) LockFetch(s *schema.Schema, filter transaction.Filter, lockPolicy transaction.LockPolicy) (*schema.Resource, error) {
+func (tx *Transaction) LockFetch(s *schema.Schema, filter transaction.Filter, lockPolicy schema.LockPolicy) (*schema.Resource, error) {
 	list, _, err := tx.LockList(s, filter, nil, lockPolicy)
 	if len(list) < 1 {
 		return nil, fmt.Errorf("Failed to fetch and lock %s", filter)

--- a/db/transaction/mocks/Transaction.go
+++ b/db/transaction/mocks/Transaction.go
@@ -108,11 +108,11 @@ func (_m *Transaction) Fetch(_a0 *schema.Schema, _a1 transaction.Filter) (*schem
 }
 
 // LockFetch provides a mock function with given fields: _a0, _a1, _a2
-func (_m *Transaction) LockFetch(_a0 *schema.Schema, _a1 transaction.Filter, _a2 transaction.LockPolicy) (*schema.Resource, error) {
+func (_m *Transaction) LockFetch(_a0 *schema.Schema, _a1 transaction.Filter, _a2 schema.LockPolicy) (*schema.Resource, error) {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *schema.Resource
-	if rf, ok := ret.Get(0).(func(*schema.Schema, transaction.Filter, transaction.LockPolicy) *schema.Resource); ok {
+	if rf, ok := ret.Get(0).(func(*schema.Schema, transaction.Filter, schema.LockPolicy) *schema.Resource); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
@@ -121,7 +121,7 @@ func (_m *Transaction) LockFetch(_a0 *schema.Schema, _a1 transaction.Filter, _a2
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*schema.Schema, transaction.Filter, transaction.LockPolicy) error); ok {
+	if rf, ok := ret.Get(1).(func(*schema.Schema, transaction.Filter, schema.LockPolicy) error); ok {
 		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
@@ -182,11 +182,11 @@ func (_m *Transaction) List(_a0 *schema.Schema, _a1 transaction.Filter, _a2 *pag
 }
 
 // LockList provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *Transaction) LockList(_a0 *schema.Schema, _a1 transaction.Filter, _a2 *pagination.Paginator, _a3 transaction.LockPolicy) ([]*schema.Resource, uint64, error) {
+func (_m *Transaction) LockList(_a0 *schema.Schema, _a1 transaction.Filter, _a2 *pagination.Paginator, _a3 schema.LockPolicy) ([]*schema.Resource, uint64, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 []*schema.Resource
-	if rf, ok := ret.Get(0).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, transaction.LockPolicy) []*schema.Resource); ok {
+	if rf, ok := ret.Get(0).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, schema.LockPolicy) []*schema.Resource); ok {
 		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
@@ -195,14 +195,14 @@ func (_m *Transaction) LockList(_a0 *schema.Schema, _a1 transaction.Filter, _a2 
 	}
 
 	var r1 uint64
-	if rf, ok := ret.Get(1).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, transaction.LockPolicy) uint64); ok {
+	if rf, ok := ret.Get(1).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, schema.LockPolicy) uint64); ok {
 		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, transaction.LockPolicy) error); ok {
+	if rf, ok := ret.Get(2).(func(*schema.Schema, transaction.Filter, *pagination.Paginator, schema.LockPolicy) error); ok {
 		r2 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r2 = ret.Error(2)

--- a/db/transaction/transaction.go
+++ b/db/transaction/transaction.go
@@ -41,13 +41,6 @@ const (
 	Serializable Type = "Serializable"
 )
 
-type LockPolicy int
-
-const (
-	LockRelatedResources LockPolicy = iota
-	SkipRelatedResources
-)
-
 //ResourceState represents the state of a resource
 type ResourceState struct {
 	ConfigVersion int64
@@ -65,10 +58,10 @@ type Transaction interface {
 	StateUpdate(*schema.Resource, *ResourceState) error
 	Delete(*schema.Schema, interface{}) error
 	Fetch(*schema.Schema, Filter) (*schema.Resource, error)
-	LockFetch(*schema.Schema, Filter, LockPolicy) (*schema.Resource, error)
+	LockFetch(*schema.Schema, Filter, schema.LockPolicy) (*schema.Resource, error)
 	StateFetch(*schema.Schema, Filter) (ResourceState, error)
 	List(*schema.Schema, Filter, *pagination.Paginator) ([]*schema.Resource, uint64, error)
-	LockList(*schema.Schema, Filter, *pagination.Paginator, LockPolicy) ([]*schema.Resource, uint64, error)
+	LockList(*schema.Schema, Filter, *pagination.Paginator, schema.LockPolicy) ([]*schema.Resource, uint64, error)
 	RawTransaction() *sqlx.Tx
 	Query(*schema.Schema, string, []interface{}) (list []*schema.Resource, err error)
 	Commit() error

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -136,7 +136,7 @@ Developers can make a schema as abstract schema specifying type=abstract. The de
 
 - nosync (boolean)
 
-We don't sync this resource for sync backend when this option is true.
+  We don't sync this resource for sync backend when this option is true.
 
 - state_versioning (boolean)
 
@@ -162,6 +162,19 @@ We don't sync this resource for sync backend when this option is true.
   Used in OpenApi documentation it allows to categorized schema according to given `resource_group` by setting appropriate tags.
   If `--split-by-resource-group` option is used to generate OpenApi documentation it will additionally place given schema to `resource_group.js` file.
 
+- locking_policy (list)
+
+  Sets if the resource should be locked in the database (using `SELECT ... FOR UPDATE`) at the beginning of `pre_update_in_transaction` and `pre_delete_in_transaction` event handling. 
+  
+  Subkeys:
+  - delete (string) - locking policy for `pre_delete_in_transaction`
+  - update (string) - locking policy for `pre_update_in_transaction`
+  
+  Allowed values:
+  - `lock_related` - locks the resource and related resources
+  - `skip_related` - locks the resource but leaves related resources unlocked
+  - (empty): default, no locking
+    
 ## Properties
 
 We need to define properties of a resource using following parameters.

--- a/extension/otto/gohan_db.go
+++ b/extension/otto/gohan_db.go
@@ -135,7 +135,7 @@ func init() {
 					call.ArgumentList = append(call.ArgumentList, defaultOffset)
 				}
 				if len(call.ArgumentList) < 7 {
-					defaultLockPolicy, _ := otto.ToValue(transaction.LockRelatedResources)
+					defaultLockPolicy, _ := otto.ToValue(schema.LockRelatedResources)
 					call.ArgumentList = append(call.ArgumentList, defaultLockPolicy)
 				}
 				VerifyCallArguments(&call, "gohan_db_lock_list", 7)
@@ -173,7 +173,7 @@ func init() {
 				if err != nil {
 					ThrowOttoException(&call, err.Error())
 				}
-				lockPolicy := transaction.LockPolicy(rawLockPolicy)
+				lockPolicy := schema.LockPolicy(rawLockPolicy)
 
 				resp, err := GohanDbLockList(tx, schemaID, filter, orderKey, limit, offset, lockPolicy)
 				if err != nil {
@@ -241,7 +241,7 @@ func init() {
 				if err != nil {
 					ThrowOttoException(&call, err.Error())
 				}
-				lockPolicy := transaction.LockPolicy(rawLockPolicy)
+				lockPolicy := schema.LockPolicy(rawLockPolicy)
 
 				resp, err := GohanDbLockFetch(tx, schemaID, ID, tenantID, lockPolicy)
 				if err != nil {
@@ -483,7 +483,7 @@ func GohanDbList(transaction transaction.Transaction, schemaID string,
 
 //GohanDbLockList locks resources in database filtered by filter and paginator
 func GohanDbLockList(tx transaction.Transaction, schemaID string,
-	filter map[string]interface{}, key string, limit uint64, offset uint64, policy transaction.LockPolicy) ([]map[string]interface{}, error) {
+	filter map[string]interface{}, key string, limit uint64, offset uint64, policy schema.LockPolicy) ([]map[string]interface{}, error) {
 
 	schema, paginator, err := prepareListResources(schemaID, key, limit, offset)
 	if err != nil {
@@ -518,7 +518,7 @@ func GohanDbFetch(tx transaction.Transaction, schemaID, ID,
 }
 
 //GohanDbLockFetch gets resource from database
-func GohanDbLockFetch(tx transaction.Transaction, schemaID, ID, tenantID string, policy transaction.LockPolicy) (*schema.Resource, error) {
+func GohanDbLockFetch(tx transaction.Transaction, schemaID, ID, tenantID string, policy schema.LockPolicy) (*schema.Resource, error) {
 	schema, err := getSchema(schemaID)
 	if err != nil {
 		return nil, err

--- a/extension/otto/gohan_db_test.go
+++ b/extension/otto/gohan_db_test.go
@@ -143,7 +143,7 @@ var _ = Describe("GohanDb", func() {
 	Describe("gohan_db_(lock)list", func() {
 		var setExpect = func(tx *mocks.Transaction, methodName string, s *schema.Schema, filter transaction.Filter, paginator *pagination.Paginator) *mock.Call {
 			if strings.Contains(methodName, "Lock") {
-				return tx.On(methodName, s, filter, paginator, transaction.LockRelatedResources)
+				return tx.On(methodName, s, filter, paginator, schema.LockRelatedResources)
 			} else {
 				return tx.On(methodName, s, filter, paginator)
 			}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -106,20 +106,24 @@ var _ = Describe("Schema", func() {
 		var metadataSchema *Schema
 		var metadataFailedSchema *Schema
 		var metadataIDSchema *Schema
+		var metadataPolicySchema *Schema
 
 		BeforeEach(func() {
 			var exists bool
 			var failedExists bool
 			var idExists bool
+			var policyExists bool
 			manager := GetManager()
 			schemaPath := "../tests/test_schema_metadata.yaml"
 			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
 			metadataSchema, exists = manager.Schema("metadata")
 			metadataFailedSchema, failedExists = manager.Schema("metadata_failed")
 			metadataIDSchema, idExists = manager.Schema("metadata_id")
+			metadataPolicySchema, policyExists = manager.Schema("metadata_policy")
 			Expect(exists).To(BeTrue())
 			Expect(failedExists).To(BeTrue())
 			Expect(idExists).To(BeTrue())
+			Expect(policyExists).To(BeTrue())
 		})
 
 		It("SyncKeyTemplate", func() {
@@ -159,6 +163,15 @@ var _ = Describe("Schema", func() {
 			Expect(path).To(Equal("/v1.0/metadata-id/1234/"))
 			str := metadataIDSchema.GetResourceIDFromPath(path)
 			Expect(str).To(Equal("1234"))
+		})
+
+		It("Should use non locking policy when unspecified", func() {
+			Expect(metadataIDSchema.GetLockingPolicy("update")).To(Equal(NoLocking))
+		})
+
+		It("Should return locking policies", func() {
+			Expect(metadataPolicySchema.GetLockingPolicy("update")).To(Equal(LockRelatedResources))
+			Expect(metadataPolicySchema.GetLockingPolicy("delete")).To(Equal(SkipRelatedResources))
 		})
 
 		AfterEach(func() {

--- a/tests/test_schema_metadata.yaml
+++ b/tests/test_schema_metadata.yaml
@@ -64,3 +64,22 @@ schemas:
     type: object
   singular: metadata_id
   title: MetadataId
+- description: MetadataPolicy
+  id: metadata_policy
+  plural: metadatas_policies
+  metadata:
+    locking_policy:
+      update: lock_related
+      delete: skip_related
+  schema:
+    properties:
+      m1:
+        description: M1
+        title: M1
+        type: string
+        unique: false
+    propertiesOrder:
+    - m1
+    type: object
+  singular: metadata_policy
+  title: MetadataPolicy


### PR DESCRIPTION
In non-trivial cases of updating/deleting a resource one may want to lock the resource at the very beginning of handling. It's an opt-in mechanism, and it's backward compatible - by default, all resources are still fetched without DB locking.