### PR TITLE
pprof server support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,9 @@ Gohan server configuration uses YAML format.
   # CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
   cors: "*"
 
+  # Enable pprof debugging endpoint at host:port
+  pprof: ":6123"
+
   # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
   logging:
       stderr:
@@ -225,6 +228,17 @@ Note: DO NOT USE * configuraion in production deployment.
 
 ```yaml
   cors: "*"
+```
+
+## Profiling
+
+Gohan can run pprof server for profiling. To start pprof server, you need to
+specify pprof address with host:port. If you do not specify an address or specify
+empty string, pprof server does not start.
+(For the detail of pprof, see https://golang.org/pkg/net/http/pprof/)
+
+```yaml
+  pprof: ":6123"
 ```
 
 ## Logging

--- a/etc/gohan.yaml
+++ b/etc/gohan.yaml
@@ -63,6 +63,9 @@ logging:
         enabled: true
         level: INFO
 
+# Enable pprof debugging endpoint at host:port
+pprof: ":6123"
+
 extension:
   default: gohanscript
   use:

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path"
@@ -184,6 +185,14 @@ func NewServer(configFile string) (*Server, error) {
 		return nil, fmt.Errorf("Logging setup error: %s", err)
 	}
 	log.Info("logging initialized")
+
+	pprof := config.GetString("pprof", "")
+	if pprof != "" {
+		go func() {
+			log.Info("pprof server started at " + pprof)
+			log.Info("%s", http.ListenAndServe(pprof, nil))
+		}()
+	}
 
 	server := &Server{}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -52,6 +52,7 @@ var (
 	childrenPluralURL = baseURL + "/v1.0/children"
 	schoolsPluralURL  = baseURL + "/v1.0/schools"
 	citiesPluralURL   = baseURL + "/v1.0/cities"
+	pprofURL		  = "http://localhost:16123/debug/pprof"
 )
 
 var _ = Describe("Server package test", func() {
@@ -1260,6 +1261,14 @@ var _ = Describe("Server package test", func() {
 			It("should verify", func() {
 				Expect(nobodyResourceService.VerifyResourcePath("/unknown")).To(BeTrue())
 				Expect(nobodyResourceService.VerifyResourcePath("/test56")).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Profiling", func() {
+		Context("Checking pprof server works", func() {
+			It("should return 200", func() {
+				testURL("GET", pprofURL, "", nil, http.StatusOK)
 			})
 		})
 	})

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -21,6 +21,8 @@ keystone:
     password: "gohan"
 cors: "*"
 
+pprof: ":16123"
+
 logging:
   stderr:
     enabled: false


### PR DESCRIPTION
For debugging long-term stability of gohan, pprof is useful profiling
tool. This patch enables gohan also starts server for pprof with
configuration in config file.