### PR TITLE
Gohan watches etcd keys with prefix for etcd v3

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,7 +347,8 @@ You can select extension types you use.
 
 a sample configuration.
 
-- watch/keys  list of watched keys in etcd. Gohan watches the path recursively.
+- watch/keys  list of watched keys in etcd. Gohan watches the pathes which start with keys for etcd v3.
+  For etcd v2, this will be done recursively.
 - events list of an event we invokes an extension
 - worker_count: number of concurrent execution tasks
 

--- a/sync/etcdv3/etcd.go
+++ b/sync/etcdv3/etcd.go
@@ -102,7 +102,7 @@ func (s *Sync) Fetch(key string) (*sync.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	dir, err := s.etcdClient.Get(s.withTimeout(), key+"/", etcd.WithPrefix(), etcd.WithSort(etcd.SortByKey, etcd.SortAscend))
+	dir, err := s.etcdClient.Get(s.withTimeout(), key, etcd.WithPrefix(), etcd.WithSort(etcd.SortByKey, etcd.SortAscend))
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (s *Sync) Watch(path string, responseChan chan *sync.Event, stopChan chan b
 	if revision != sync.RevisionCurrent {
 		options = append(options, etcd.WithMinModRev(revision+1))
 	}
-	node, err := s.etcdClient.Get(s.withTimeout(), path+"/", options...)
+	node, err := s.etcdClient.Get(s.withTimeout(), path, options...)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func (s *Sync) Watch(path string, responseChan chan *sync.Event, stopChan chan b
 	go func() {
 		defer wg.Done()
 		err := func() error {
-			rch := s.etcdClient.Watch(ctx, path+"/", etcd.WithPrefix(), etcd.WithRev(revision))
+			rch := s.etcdClient.Watch(ctx, path, etcd.WithPrefix(), etcd.WithRev(revision))
 
 			for wresp := range rch {
 				err := wresp.Err()


### PR DESCRIPTION
Current etcd v3 support has too strict backward compatibility for etcd
fetch and watch. Due to this, gohan cannot watch etcd keys with prefix
even though Etcd v3 supports listing in prefix. This patch enables
fetch/watch etcd key with prefix. Actually, this patch keeps backward
compatibility.

Usecase: Load balancing of etcd watch in HA environment