### PR TITLE
Sync watch load balancing and auto rebalancing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -376,6 +376,40 @@ Any monitoring updates made when the state version does not yet equal
 the config version or the version in the JSON data doesn't match with
 the config version will be ignored.
 
+## Sync watch
+
+Gohan has another way to handle data reported from sync layer. Gohan
+will watch sync keys with prefix then if its key's creation/update/deletion
+happens, gohan will occur ``notification`` type event with action and data.
+Sync keys and event path can be configured in ``gohan.yaml`` configuration file like:
+
+```yaml
+  watch:
+      keys:
+        - /v2.0/servers
+        - /v2.0/systems
+      events:
+        - v2.0
+      worker_count: 4
+```
+
+With an above configuration example, gohan will watch the updates of sync keys including
+``/v2.0/servers`` and ``/v2.0/systems`` as an prefix. If gohan detected some changes,
+emitted events can be handled by gohan extension by configuring following extensions configuration,
+for example:
+
+```yaml
+extensions:
+- id: sync_watch_handler
+  path: "v2.0"
+  url: ./handler.js
+```
+
+In Gohan HA environment, watched keys are load-balanced among working gohan instances.
+Even if new gohan instance is added or some gohan instance is stopped, each gohan will
+automatically detect instance addition and deletion then watched keys are automatically
+reballanced.
+
 ## Migrate
 
 gohan migrate command is a simple wrapper for goose command.

--- a/server/process_watch.go
+++ b/server/process_watch.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"time"
+
+	gohan_sync "github.com/cloudwan/gohan/sync"
+)
+
+const processPath = "/gohan/cluster/process"
+
+//Watch Process Availability
+func StartProcessWatchProcess(server *Server) {
+	responseChan := make(chan *gohan_sync.Event)
+	stopChan := make(chan bool)
+	server.respChanProcessWatch = responseChan
+	server.stopChanProcessWatch = stopChan
+
+	go func() {
+		for server.running {
+			fromRevision := int64(gohan_sync.RevisionCurrent)
+			// register self process to the cluster
+			lockKey := processPath + "/" + server.sync.GetProcessID()
+			server.sync.Lock(lockKey, true)
+			// start process watch
+			err := server.sync.Watch(processPath, responseChan, stopChan, fromRevision)
+			if err != nil {
+				log.Error(fmt.Sprintf("process watch error: %s", err))
+				time.Sleep(5 * time.Second)
+			}
+			server.sync.Unlock(lockKey)
+		}
+	}()
+}
+
+//Stop Watch Process
+func StopProcessWatchProcess(server *Server) {
+	close(server.stopChanProcessWatch)
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1345,6 +1345,7 @@ func startTestServer(config string) error {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+	server.SetRunning(true)
 
 	return nil
 }

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -25,3 +25,15 @@ logging:
   stderr:
     enabled: false
     level: ERROR
+
+watch:
+  keys:
+  - /watch/key/1
+  - /watch/key/2
+  - /watch/key/3
+  - /watch/key/4
+  - /watch/key/5
+  - /watch/key/6
+  events:
+  - watch/key
+  worker_count: 4

--- a/server/server_test_mysql_config.yaml
+++ b/server/server_test_mysql_config.yaml
@@ -30,3 +30,15 @@ logging:
         enabled: true
         level: CRITICAL
         filename: ./gohan.log
+
+watch:
+  keys:
+  - /watch/key/1
+  - /watch/key/2
+  - /watch/key/3
+  - /watch/key/4
+  - /watch/key/5
+  - /watch/key/6
+  events:
+  - watch/key
+  worker_count: 4

--- a/server/sync_watch_test.go
+++ b/server/sync_watch_test.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudwan/gohan/schema"
+	srv "github.com/cloudwan/gohan/server"
+)
+
+const (
+	lockPathPrefix = "/gohan/cluster/lock/watch"
+
+	processPathPrefix = "/gohan/cluster/process"
+
+	masterTTL = 10
+)
+
+var _ = Describe("Sync watch test", func() {
+	BeforeEach(func() {
+		// start process watcher and sync watcher
+		srv.StartProcessWatchProcess(server)
+		srv.StartSyncWatchProcess(server)
+	})
+
+	AfterEach(func() {
+		tx, err := testDB.Begin()
+		Expect(err).ToNot(HaveOccurred(), "Failed to create transaction.")
+		defer tx.Close()
+		for _, schema := range schema.GetManager().Schemas() {
+			if whitelist[schema.ID] {
+				continue
+			}
+			err = clearTable(tx, schema)
+			Expect(err).ToNot(HaveOccurred(), "Failed to clear table.")
+		}
+		err = tx.Commit()
+		Expect(err).ToNot(HaveOccurred(), "Failed to commit transaction.")
+	})
+
+	Describe("Sync watch load balancing with HA", func() {
+
+		It("should be load balanced based on process number", func() {
+			// Run as Single Node
+			sync := server.GetSync()
+			prn, err := sync.Fetch(processPathPrefix)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(prn.Children)).To(Equal(1))
+
+			time.Sleep(time.Second)
+
+			// Only single node, so all watch pathes are taken with this process
+			wrn, err := sync.Fetch(lockPathPrefix + "/watch/key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(wrn.Children)).To(Equal(6))
+
+			// (Simulate) New process joined gohan cluster
+			newProcessUUID := "ffffffff-ffff-ffff-ffff-fffffffffffe"
+			err = sync.Update(processPathPrefix + "/" + newProcessUUID, newProcessUUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Now, process watcher detects two processes running
+			prn, err = sync.Fetch(processPathPrefix)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(prn.Children)).To(Equal(2))
+
+			time.Sleep(masterTTL / 2 * time.Second)
+
+			// Watched pathes should be load balanced
+			// So, this process started watching half of them based on priority
+			wrn, err = sync.Fetch(lockPathPrefix + "/watch/key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(wrn.Children)).To(Equal(3))
+
+			time.Sleep(masterTTL * time.Second)
+
+			// It looks other process failed to start watching.
+			// So, this process started watching rest half of them
+			wrn, err = sync.Fetch(lockPathPrefix + "/watch/key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(wrn.Children)).To(Equal(6))
+
+			// (Simulate) One more process joined gohan cluster
+			newProcessUUID2 := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+			err = sync.Update(processPathPrefix + "/" + newProcessUUID2, newProcessUUID2)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Now, process watcher detects three processes running
+			prn, err = sync.Fetch(processPathPrefix)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(prn.Children)).To(Equal(3))
+
+			time.Sleep(masterTTL / 2 * time.Second)
+
+			// Watched pathes are load balanced by 3 processes
+			// So, this process started watching two of them based on priority
+			wrn, err = sync.Fetch(lockPathPrefix + "/watch/key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(wrn.Children)).To(Equal(2))
+
+			// (Simulate) One process of gohan cluster is down
+			err = sync.Delete(processPathPrefix + "/" + newProcessUUID, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			time.Sleep(time.Second)
+
+			// Now, process watcher detects two processes running
+			prn, err = sync.Fetch(processPathPrefix)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(prn.Children)).To(Equal(2))
+
+			time.Sleep(masterTTL / 2 * time.Second)
+
+			// This process started watching half of them again based on priority
+			wrn, err = sync.Fetch(lockPathPrefix + "/watch/key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(wrn.Children)).To(Equal(3))
+		})
+	})
+
+})

--- a/sync/etcd/etcd.go
+++ b/sync/etcd/etcd.go
@@ -16,6 +16,7 @@
 package etcd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -27,7 +28,10 @@ import (
 	"github.com/twinj/uuid"
 )
 
-const masterTTL = 10
+const (
+	processPath = "/gohan/cluster/process"
+	masterTTL   = 10
+)
 
 //Sync is struct for etcd based sync
 type Sync struct {
@@ -43,6 +47,11 @@ func NewSync(etcdServers []string) *Sync {
 	hostname, _ := os.Hostname()
 	sync.processID = hostname + uuid.NewV4().String()
 	return sync
+}
+
+//GetProcessID returns processID
+func (s *Sync) GetProcessID() string {
+	return s.processID
 }
 
 //Update sync update sync
@@ -222,6 +231,29 @@ func (s *Sync) Watch(path string, responseChan chan *sync.Event, stopChan chan b
 			return nil
 		}
 	}
+}
+
+// WatchContext keep watch update under the path until context is canceled
+func (s *Sync) WatchContext(ctx context.Context, path string, revision int64) (<-chan *sync.Event, error) {
+	stopChan := make(chan bool)
+	go func() {
+		<-ctx.Done()
+		close(stopChan)
+	}()
+
+	responseChan := make(chan *sync.Event)
+
+	go func() {
+		defer close(responseChan)
+		err := s.Watch(path, responseChan, stopChan, revision)
+		if err != nil {
+			responseChan <- &sync.Event{
+				Err: err,
+			}
+		}
+	}()
+
+	return responseChan, nil
 }
 
 func (s *Sync) Close() {

--- a/sync/noop/noop.go
+++ b/sync/noop/noop.go
@@ -15,7 +15,11 @@
 
 package noop
 
-import "github.com/cloudwan/gohan/sync"
+import (
+	"context"
+
+	"github.com/cloudwan/gohan/sync"
+)
 
 //Sync is struct for noop
 type Sync struct {
@@ -24,6 +28,11 @@ type Sync struct {
 //NewSync creates noop sync instance
 func NewSync() *Sync {
 	return &Sync{}
+}
+
+//GetProcessID returns processID
+func (sync *Sync) GetProcessID() string {
+	return ""
 }
 
 //Update sync update sync
@@ -58,6 +67,11 @@ func (sync *Sync) Unlock(path string) error {
 //Watch keep watch update under the path
 func (sync *Sync) Watch(path string, responseChan chan *sync.Event, stopChan chan bool, revision int64) error {
 	return nil
+}
+
+//WatchContext keep watch update under the path until context is canceled
+func (sync *Sync) WatchContext(ctx context.Context, path string, revision int64) (<-chan *sync.Event, error) {
+	return nil, nil
 }
 
 func (sync *Sync) Close() {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -15,7 +15,11 @@
 
 package sync
 
-import l "github.com/cloudwan/gohan/log"
+import (
+	"context"
+
+	l "github.com/cloudwan/gohan/log"
+)
 
 const RevisionCurrent = -1
 
@@ -35,6 +39,9 @@ type Sync interface {
 	// give ReivisionCurrent when you want to start from the current reivision.
 	// Returnes an error when gets any error including connection failures.
 	Watch(path string, responseChan chan *Event, stopChan chan bool, revision int64) error
+	//WatchContext keep watch update under the path until context is canceled.
+	WatchContext(ctx context.Context, path string, revision int64) (<-chan *Event, error)
+	GetProcessID() string
 	Close()
 }
 
@@ -44,6 +51,8 @@ type Event struct {
 	Key      string
 	Data     map[string]interface{}
 	Revision int64
+	// Err is used only by Sync.WatchContext()
+	Err error
 }
 
 //Node is a struct for Fetch response


### PR DESCRIPTION
Even if Gohan works as HA, state_watch and sync_watch are done in one
gohan process, and in many cases, both are done in the same process.
This can be a scale problem to handle southbound status update.

This patch enables gohan cluster to load-balance sync_watch keys. In
addition, on process increase/decrease, each process automatically
rebalances watch keys then re-assign keys based on calculated priority.
To enable this feature, the following logics are added.

1. New goroutine process_watch will watch under /gohan/cluster/process
   path. Process ID of running gohan is registered under this path, so
   each gohan process can be notified how many gohan processes are
   running in the same cluster.

2. In rebalance process, the priority for each watch path is calculated
   on each gohan process. For "low priority" path (actually higher
   priority has lower number for caluculation ease), it will take longer
   wait time for other gohan process to preferentially acquire a lock
   for the path.