### PR TITLE
Any properties are not appended for custom sql data type

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -311,15 +311,16 @@ func (db *DB) genTableCols(s *schema.Schema, cascade bool, exclude []string) ([]
 			sqlDataType = handler.dataType(&property)
 			if property.ID == "id" {
 				sqlDataProperties = " primary key"
+			}
+		}
+		if property.ID != "id" {
+			if property.Nullable {
+				sqlDataProperties = " null"
 			} else {
-				if property.Nullable {
-					sqlDataProperties = " null"
-				} else {
-					sqlDataProperties = " not null"
-				}
-				if property.Unique {
-					sqlDataProperties = " unique"
-				}
+				sqlDataProperties = " not null"
+			}
+			if property.Unique {
+				sqlDataProperties = " unique"
 			}
 		}
 		sql := "`" + property.ID + "` " + sqlDataType + sqlDataProperties

--- a/db/sql/sql_test.go
+++ b/db/sql/sql_test.go
@@ -293,7 +293,7 @@ var _ = Describe("Sql", func() {
 				))
 				table, _, err := sqlConn.AlterTableDef(server, true)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(table).To(ContainSubstring("alter table`servers` add (`test` varchar(255));"))
+				Expect(table).To(ContainSubstring("alter table`servers` add (`test` varchar(255) not null);"))
 			})
 
 			It("Create index if property should be indexed", func() {


### PR DESCRIPTION
If custom sql type is used in schema file, nullable nor unique is
applied to generated SQL statements. This patch fixed this issue.

This patch modifies one line of unit test. I think unit test itself was
wrong.