### PR TITLE
pprof server support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,11 @@ Gohan server configuration uses YAML format.
   # CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
   cors: "*"
 
+  # Profiling configuration
+  profiling:
+      # if true, gohan add routes /debug/pprof/ for pprof profiling
+      enabled: true
+
   # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",
   logging:
       stderr:
@@ -230,6 +235,26 @@ Note: DO NOT USE * configuraion in production deployment.
 ```yaml
   cors: "*"
 ```
+
+## Profiling
+
+Gohan runs with pprof profiling feature. You can get profiling results by querying
+``http://<gohan_host>:<gohan_port>/debug/pprof/*`` . To get the profiling result,
+you need admin credentials.
+
+You can use profiling feature by set ``profiling/enabled`` as ``true``.
+
+```yaml
+  profiling:
+      enabled: true
+```
+
+For the detail of pprof, please see https://golang.org/pkg/net/http/pprof/ .
+
+NOTE: authentication is not provided under ``/debug/pprof/`` path, so when
+you enable pprof on production environment, you should block the access to
+this URL with a different way.
+
 
 ## Logging
 

--- a/etc/gohan.yaml
+++ b/etc/gohan.yaml
@@ -51,6 +51,11 @@ keystone:
 # CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
 # cors: "*"
 
+# Profiling configuration
+profiling:
+    # if true, gohan add routes /debug/pprof/ for pprof profiling
+    enabled: true
+
 # Generate webui config
 webui_config:
     # if true, gohan generates webui config.json

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -258,6 +258,11 @@ func Authentication() martini.Handler {
 			return
 		}
 
+		if strings.HasPrefix(req.URL.Path, "/debug/pprof/") {
+			c.Next()
+			return
+		}
+
 		authToken := req.Header.Get("X-Auth-Token")
 
 		var targetIdentityService IdentityService

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -54,6 +54,7 @@ var (
 	childrenPluralURL = baseURL + "/v1.0/children"
 	schoolsPluralURL  = baseURL + "/v1.0/schools"
 	citiesPluralURL   = baseURL + "/v1.0/cities"
+	profilingURL	  = baseURL + "/debug/pprof/"
 )
 
 var _ = Describe("Server package test", func() {
@@ -1264,6 +1265,14 @@ var _ = Describe("Server package test", func() {
 			It("should verify", func() {
 				Expect(nobodyResourceService.VerifyResourcePath("/unknown")).To(BeTrue())
 				Expect(nobodyResourceService.VerifyResourcePath("/test56")).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Profiling", func() {
+		Context("Checking pprof server works", func() {
+			It("should return 200", func() {
+				testURL("GET", profilingURL, "", nil, http.StatusOK)
 			})
 		})
 	})

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -21,6 +21,9 @@ keystone:
     password: "gohan"
 cors: "*"
 
+profiling:
+  enabled: true
+
 logging:
   stderr:
     enabled: false


### PR DESCRIPTION
For debugging long-term stability of gohan, pprof is useful profiling
tool. This patch enables gohan also starts server with profiling
feature.