### PR TITLE
[ESI-13047] Retryable transactions

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -305,12 +305,14 @@ func (db *DB) Begin() (tx transaction.Transaction, err error) {
 	if db.sqlType == "sqlite3" {
 		rawTx.Exec("PRAGMA foreign_keys = ON;")
 	}
-	tx = &Transaction{
-		db:             db,
-		transaction:    rawTx,
-		closed:         false,
-		isolationLevel: transaction.RepeatableRead,
-	}
+	tx = transaction.NewRetryableTransaction(
+		&Transaction{
+			db:             db,
+			transaction:    rawTx,
+			closed:         false,
+			isolationLevel: transaction.RepeatableRead,
+		},
+	)
 	log.Debug("[%p] Created transaction %#v, isolation level: %s", rawTx, rawTx, tx.GetIsolationLevel())
 	return
 }
@@ -329,12 +331,14 @@ func (db *DB) BeginTx(ctx context.Context, options *transaction.TxOptions) (tx t
 	if db.sqlType == "sqlite3" {
 		rawTx.Exec("PRAGMA foreign_keys = ON;")
 	}
-	tx = &Transaction{
-		db:             db,
-		transaction:    rawTx,
-		closed:         false,
-		isolationLevel: options.IsolationLevel,
-	}
+	tx = transaction.NewRetryableTransaction(
+		&Transaction{
+			db:             db,
+			transaction:    rawTx,
+			closed:         false,
+			isolationLevel: options.IsolationLevel,
+		},
+	)
 	log.Debug("[%p] Created transaction %#v, isolation level %s", rawTx, rawTx, tx.GetIsolationLevel())
 	return
 }

--- a/db/transaction/log.go
+++ b/db/transaction/log.go
@@ -1,0 +1,5 @@
+package transaction
+
+import l "github.com/cloudwan/gohan/log"
+
+var log = l.NewLogger()

--- a/db/transaction/retryable_transaction.go
+++ b/db/transaction/retryable_transaction.go
@@ -1,0 +1,171 @@
+package transaction
+
+import (
+	"time"
+
+	"strings"
+
+	"github.com/cloudwan/gohan/db/pagination"
+	"github.com/cloudwan/gohan/schema"
+	"github.com/cloudwan/gohan/util"
+	"github.com/jmoiron/sqlx"
+)
+
+const NUMBER_OF_RETRIES_CONFIG_KEY = "database/transaction_retries/attempts"
+const RETRY_STRATEGY_CONFIG_KEY = "database/transaction_retries/strategy"
+const INTERVAL_BETWEEN_ATTEMPTS_CONFIG_KEY = "database/transaction_retries/interval_between_attempts"
+const DEFAULT_NUMBER_OF_RETRIES = 1
+const DEFAULT_RETRY_STRATEGY = "deadlock"
+const DEFAULT_INTERVAL_BETWEEN_ATTEMPTS = "100ms"
+
+const MYSQL_DEADLOCK_MSG = "Error 1213: Deadlock found when trying to get lock; try restarting transaction"
+const SQLITE_DEADLOCK_MSG = "database is locked"
+
+type RetryConfig struct {
+	Attempts      int
+	Strategy      RetryStrategyPredicate
+	SleepInterval time.Duration
+}
+
+var cache RetryConfig
+var cacheInitialized = false
+
+type RetryableTransaction struct {
+	Tx     Transaction
+	Config RetryConfig
+}
+
+type RetryStrategyPredicate func(error) bool
+
+var strategies = map[string]RetryStrategyPredicate{
+	"deadlock": IsDeadlock,
+}
+
+func NewRetryableTransaction(transaction Transaction) Transaction {
+	config := readConfig()
+	tx := &RetryableTransaction{
+		Tx:     transaction,
+		Config: config,
+	}
+	log.Debug("Created retryable transaction tx: %v, rawTx: %v, attempts: %d, interval: %s", &tx, transaction.RawTransaction(), config.Attempts, config.SleepInterval)
+	return tx
+}
+
+func IsDeadlock(err error) bool {
+	return strings.Contains(err.Error(), MYSQL_DEADLOCK_MSG) || strings.Contains(err.Error(), SQLITE_DEADLOCK_MSG)
+}
+
+func readConfig() RetryConfig {
+	if cacheInitialized {
+		return cache
+	}
+	config := util.GetConfig()
+	attempts := config.GetInt(NUMBER_OF_RETRIES_CONFIG_KEY, DEFAULT_NUMBER_OF_RETRIES)
+	configStrategy := config.GetString(RETRY_STRATEGY_CONFIG_KEY, DEFAULT_RETRY_STRATEGY)
+	retryStrategy, ok := strategies[configStrategy]
+	if !ok {
+		log.Error("%s Strategy isn't implemented, using default one: %s", configStrategy, DEFAULT_INTERVAL_BETWEEN_ATTEMPTS)
+		retryStrategy = strategies[DEFAULT_INTERVAL_BETWEEN_ATTEMPTS]
+	}
+	sleepInterval, parseErr := time.ParseDuration(config.GetString(INTERVAL_BETWEEN_ATTEMPTS_CONFIG_KEY, DEFAULT_INTERVAL_BETWEEN_ATTEMPTS))
+	if parseErr != nil {
+		log.Error("Failed to parse retry interval from config, using default one: %s", DEFAULT_INTERVAL_BETWEEN_ATTEMPTS)
+		sleepInterval, _ = time.ParseDuration(DEFAULT_INTERVAL_BETWEEN_ATTEMPTS)
+	}
+	cache = RetryConfig{
+		Attempts:      attempts,
+		Strategy:      retryStrategy,
+		SleepInterval: sleepInterval,
+	}
+	cacheInitialized = true
+	return cache
+}
+
+func (t *RetryableTransaction) retryOnError(f func() error) (err error) {
+	for attempt := 1; true; attempt++ {
+		err = f()
+		if err != nil && t.Config.Strategy(err) && (t.Config.Attempts < 0 || attempt < t.Config.Attempts) {
+			log.Debug("Retrying tx: %v, attempt %d/%d, sleeping %s", &t, attempt+1, t.Config.Attempts, t.Config.SleepInterval)
+			time.Sleep(t.Config.SleepInterval)
+		} else {
+			return
+		}
+	}
+	return
+}
+
+func (t *RetryableTransaction) Create(resource *schema.Resource) error {
+	return t.retryOnError(func() error { return t.Tx.Create(resource) })
+}
+
+func (t *RetryableTransaction) Update(resource *schema.Resource) error {
+	return t.retryOnError(func() error { return t.Tx.Update(resource) })
+}
+func (t *RetryableTransaction) StateUpdate(resource *schema.Resource, state *ResourceState) error {
+	return t.retryOnError(func() error { return t.Tx.StateUpdate(resource, state) })
+}
+func (t *RetryableTransaction) Delete(schema *schema.Schema, resourceID interface{}) error {
+	return t.retryOnError(func() error { return t.Tx.Delete(schema, resourceID) })
+}
+func (t *RetryableTransaction) Fetch(schema *schema.Schema, filter Filter) (resource *schema.Resource, err error) {
+	t.retryOnError(func() error {
+		resource, err = t.Tx.Fetch(schema, filter)
+		return err
+	})
+	return
+}
+func (t *RetryableTransaction) LockFetch(schema *schema.Schema, filter Filter, lockPolicy schema.LockPolicy) (resource *schema.Resource, err error) {
+	t.retryOnError(func() error {
+		resource, err = t.Tx.LockFetch(schema, filter, lockPolicy)
+		return err
+	})
+	return
+}
+func (t *RetryableTransaction) StateFetch(schema *schema.Schema, filter Filter) (state ResourceState, err error) {
+	t.retryOnError(func() error {
+		state, err = t.Tx.StateFetch(schema, filter)
+		return err
+	})
+	return
+
+}
+func (t *RetryableTransaction) List(schema *schema.Schema, filter Filter, listOptions *ListOptions, pg *pagination.Paginator) (resources []*schema.Resource, total uint64, err error) {
+	t.retryOnError(func() error {
+		resources, total, err = t.Tx.List(schema, filter, listOptions, pg)
+		return err
+	})
+	return
+}
+func (t *RetryableTransaction) LockList(schema *schema.Schema, filter Filter, listOptions *ListOptions, pg *pagination.Paginator, lockPolicy schema.LockPolicy) (resources []*schema.Resource, total uint64, err error) {
+	t.retryOnError(func() error {
+		resources, total, err = t.Tx.LockList(schema, filter, listOptions, pg, lockPolicy)
+		return err
+	})
+	return
+}
+func (t *RetryableTransaction) RawTransaction() *sqlx.Tx {
+	return t.Tx.RawTransaction()
+
+}
+func (t *RetryableTransaction) Query(schema *schema.Schema, query string, arguments []interface{}) (list []*schema.Resource, err error) {
+	t.retryOnError(func() error {
+		list, err = t.Tx.Query(schema, query, arguments)
+		return err
+	})
+	return
+}
+func (t *RetryableTransaction) Commit() error {
+	return t.Tx.Commit()
+}
+func (t *RetryableTransaction) Exec(query string, args ...interface{}) error {
+	return t.retryOnError(func() error { return t.Tx.Exec(query, args) })
+}
+func (t *RetryableTransaction) Close() error {
+	return t.Tx.Close()
+}
+func (t *RetryableTransaction) Closed() bool {
+	return t.Tx.Closed()
+}
+func (t *RetryableTransaction) GetIsolationLevel() Type {
+	return t.Tx.GetIsolationLevel()
+}

--- a/db/transaction/transaction_suite_test.go
+++ b/db/transaction/transaction_suite_test.go
@@ -1,0 +1,19 @@
+package transaction_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var ctrl *gomock.Controller
+
+func TestTransaction(t *testing.T) {
+	RegisterFailHandler(Fail)
+	ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	RunSpecs(t, "Transaction Suite")
+}

--- a/db/transaction/transaction_test.go
+++ b/db/transaction/transaction_test.go
@@ -1,0 +1,254 @@
+package transaction_test
+
+import (
+	"errors"
+
+	"time"
+
+	"github.com/cloudwan/gohan/db/transaction"
+	"github.com/cloudwan/gohan/db/transaction/mocks"
+	"github.com/cloudwan/gohan/schema"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Retryable Transaction", func() {
+
+	var any = gomock.Any()
+	var retryConfig transaction.RetryConfig
+
+	var givenNumberOfAttempts = func(attempts int) {
+		retryConfig.Attempts = attempts
+	}
+
+	var givenSleepInterval = func(interval time.Duration) {
+		retryConfig.SleepInterval = interval
+	}
+
+	var givenRetryStrategy = func(strategy transaction.RetryStrategyPredicate) {
+		retryConfig.Strategy = strategy
+	}
+
+	BeforeEach(func() {
+		givenRetryStrategy(transaction.IsDeadlock)
+		givenNumberOfAttempts(2)
+		givenSleepInterval(0 * time.Millisecond)
+	})
+
+	Context("Retry logic", func() {
+		var rawTxMock *mocks.MockTransaction
+		var sut transaction.RetryableTransaction
+
+		BeforeEach(func() {
+			rawTxMock = mocks.NewMockTransaction(ctrl)
+			givenNumberOfAttempts(2)
+			sut = transaction.RetryableTransaction{
+				Tx:     rawTxMock,
+				Config: retryConfig,
+			}
+		})
+
+		It("Number of attempts specified by config", func() {
+			givenNumberOfAttempts(3)
+			sut = transaction.RetryableTransaction{
+				Tx:     rawTxMock,
+				Config: retryConfig,
+			}
+			err := errors.New(transaction.MYSQL_DEADLOCK_MSG)
+			rawTxMock.EXPECT().Create(any).Return(err)
+			rawTxMock.EXPECT().Create(any).Return(err)
+			rawTxMock.EXPECT().Create(any).Return(err)
+			Expect(sut.Create(nil)).To(Equal(err))
+		})
+
+		It("No retry if error is not recognized by strategy", func() {
+			err := errors.New("Other error")
+			rawTxMock.EXPECT().Create(any).Return(err)
+			Expect(sut.Create(nil)).To(Equal(err))
+		})
+
+		It("No retry if error is nil", func() {
+			rawTxMock.EXPECT().Create(any).Return(nil)
+			Expect(sut.Create(nil)).To(Succeed())
+		})
+	})
+
+	Context("Mysql backend", func() {
+		var rawTxMock *mocks.MockTransaction
+		var sut transaction.RetryableTransaction
+
+		BeforeEach(func() {
+			rawTxMock = mocks.NewMockTransaction(ctrl)
+			sut = transaction.RetryableTransaction{
+				Tx:     rawTxMock,
+				Config: retryConfig,
+			}
+		})
+
+		It("Retry Create on deadlock", func() {
+			rawTxMock.EXPECT().Create(any).Return(errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Create(any).Return(nil)
+			Expect(sut.Create(nil)).To(Succeed())
+		})
+
+		It("Retry Update on deadlock", func() {
+			rawTxMock.EXPECT().Update(any).Return(errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Update(any).Return(nil)
+			Expect(sut.Update(nil)).To(Succeed())
+		})
+		It("Retry StateUpdate on deadlock", func() {
+			rawTxMock.EXPECT().StateUpdate(any, any).Return(errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().StateUpdate(any, any).Return(nil)
+			Expect(sut.StateUpdate(nil, nil)).To(Succeed())
+		})
+		It("Retry Delete on deadlock", func() {
+			rawTxMock.EXPECT().Delete(any, any).Return(errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Delete(any, any).Return(nil)
+			Expect(sut.Delete(nil, nil)).To(Succeed())
+		})
+		It("Retry Fetch on deadlock", func() {
+			rawTxMock.EXPECT().Fetch(any, any).Return(nil, errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Fetch(any, any).Return(nil, nil)
+			_, err := sut.Fetch(nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry LockFetch on deadlock", func() {
+			rawTxMock.EXPECT().LockFetch(any, any, any).Return(nil, errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().LockFetch(any, any, any).Return(nil, nil)
+			_, err := sut.LockFetch(nil, nil, schema.NoLocking)
+			Expect(err).To(BeNil())
+		})
+		It("Retry StateFetch on deadlock", func() {
+			rv := transaction.ResourceState{}
+			rawTxMock.EXPECT().StateFetch(any, any).Return(rv, errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().StateFetch(any, any).Return(rv, nil)
+			_, err := sut.StateFetch(nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry List on deadlock", func() {
+			rawTxMock.EXPECT().List(any, any, any, any).Return(nil, uint64(0), errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().List(any, any, any, any).Return(nil, uint64(0), nil)
+			_, _, err := sut.List(nil, nil, nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry LockList on deadlock", func() {
+			rawTxMock.EXPECT().LockList(any, any, any, any, any).Return(nil, uint64(0), errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().LockList(any, any, any, any, any).Return(nil, uint64(0), nil)
+			_, _, err := sut.LockList(nil, nil, nil, nil, schema.NoLocking)
+			Expect(err).To(BeNil())
+		})
+		It("Retry Query on deadlock", func() {
+			rawTxMock.EXPECT().Query(any, any, any).Return(nil, errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Query(any, any, any).Return(nil, nil)
+			_, err := sut.Query(nil, "", nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry Exec on deadlock", func() {
+			rawTxMock.EXPECT().Exec(any, any).Return(errors.New(transaction.MYSQL_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Exec(any, any).Return(nil)
+			Expect(sut.Exec("", nil)).To(Succeed())
+		})
+
+		It("Commit not retryable", func() {
+			err := errors.New(transaction.MYSQL_DEADLOCK_MSG)
+			rawTxMock.EXPECT().Commit().Return(err)
+			Expect(sut.Commit()).To(Equal(err))
+		})
+
+		It("Close not retryable", func() {
+			err := errors.New(transaction.MYSQL_DEADLOCK_MSG)
+			rawTxMock.EXPECT().Close().Return(err)
+			Expect(sut.Close()).To(Equal(err))
+		})
+	})
+
+	Context("SQLite backend", func() {
+		var rawTxMock *mocks.MockTransaction
+		var sut transaction.RetryableTransaction
+
+		BeforeEach(func() {
+			rawTxMock = mocks.NewMockTransaction(ctrl)
+			sut = transaction.RetryableTransaction{
+				Tx:     rawTxMock,
+				Config: retryConfig,
+			}
+		})
+
+		It("Retry Create on deadlock", func() {
+			rawTxMock.EXPECT().Create(any).Return(errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Create(any).Return(nil)
+			Expect(sut.Create(nil)).To(Succeed())
+		})
+
+		It("Retry Update on deadlock", func() {
+			rawTxMock.EXPECT().Update(any).Return(errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Update(any).Return(nil)
+			Expect(sut.Update(nil)).To(Succeed())
+		})
+		It("Retry StateUpdate on deadlock", func() {
+			rawTxMock.EXPECT().StateUpdate(any, any).Return(errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().StateUpdate(any, any).Return(nil)
+			Expect(sut.StateUpdate(nil, nil)).To(Succeed())
+		})
+		It("Retry Delete on deadlock", func() {
+			rawTxMock.EXPECT().Delete(any, any).Return(errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Delete(any, any).Return(nil)
+			Expect(sut.Delete(nil, nil)).To(Succeed())
+		})
+		It("Retry Fetch on deadlock", func() {
+			rawTxMock.EXPECT().Fetch(any, any).Return(nil, errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Fetch(any, any).Return(nil, nil)
+			_, err := sut.Fetch(nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry LockFetch on deadlock", func() {
+			rawTxMock.EXPECT().LockFetch(any, any, any).Return(nil, errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().LockFetch(any, any, any).Return(nil, nil)
+			_, err := sut.LockFetch(nil, nil, schema.NoLocking)
+			Expect(err).To(BeNil())
+		})
+		It("Retry StateFetch on deadlock", func() {
+			rv := transaction.ResourceState{}
+			rawTxMock.EXPECT().StateFetch(any, any).Return(rv, errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().StateFetch(any, any).Return(rv, nil)
+			_, err := sut.StateFetch(nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry List on deadlock", func() {
+			rawTxMock.EXPECT().List(any, any, any, any).Return(nil, uint64(0), errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().List(any, any, any, any).Return(nil, uint64(0), nil)
+			_, _, err := sut.List(nil, nil, nil, nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry LockList on deadlock", func() {
+			rawTxMock.EXPECT().LockList(any, any, any, any, any).Return(nil, uint64(0), errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().LockList(any, any, any, any, any).Return(nil, uint64(0), nil)
+			_, _, err := sut.LockList(nil, nil, nil, nil, schema.NoLocking)
+			Expect(err).To(BeNil())
+		})
+		It("Retry Query on deadlock", func() {
+			rawTxMock.EXPECT().Query(any, any, any).Return(nil, errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Query(any, any, any).Return(nil, nil)
+			_, err := sut.Query(nil, "", nil)
+			Expect(err).To(BeNil())
+		})
+		It("Retry Exec on deadlock", func() {
+			rawTxMock.EXPECT().Exec(any, any).Return(errors.New(transaction.SQLITE_DEADLOCK_MSG))
+			rawTxMock.EXPECT().Exec(any, any).Return(nil)
+			Expect(sut.Exec("", nil)).To(Succeed())
+		})
+
+		It("Commit not retryable", func() {
+			err := errors.New(transaction.SQLITE_DEADLOCK_MSG)
+			rawTxMock.EXPECT().Commit().Return(err)
+			Expect(sut.Commit()).To(Equal(err))
+		})
+
+		It("Close not retryable", func() {
+			err := errors.New(transaction.SQLITE_DEADLOCK_MSG)
+			rawTxMock.EXPECT().Close().Return(err)
+			Expect(sut.Close()).To(Equal(err))
+		})
+	})
+})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,10 @@ Gohan server configuration uses YAML format.
       # auto_migrate: true
       # please set no_init true in the production env, so that gohan don't initialize table
       # no_init: true
+      transaction_retries:
+          attempts: 3                        # Number of attempts in case of error recognized by strategy
+          strategy: "deadlock"               # choosen strategy, only "deadlock" is implemented
+          interval_between_attempts: "100ms" # sleep between attemps, string with parsable (time.Duration) interval
       initial_data:
           - type: "yaml"
             connection: "./etc/examples/heat_template.yaml"


### PR DESCRIPTION
Ability to specify strategy to decide whether transaction returning error should be retried automatically.
It's configurable and by default retry is turned off.
The only implemented strategy is on deadlock.