### PR TITLE
Added builtin with null support for updates

### DIFF
--- a/docs/js_extension.md
+++ b/docs/js_extension.md
@@ -154,6 +154,10 @@ create data in db
 
 update data in db
 
+- gohan_db_update_with_nulls(transaction, schema_id, object, fields)
+
+update data in db with setting all fields to null
+
 - gohan_db_state_update(transaction, schema_id, object)
 
 update data in db without informing etcd

--- a/extension/framework/runner/test_data/gohan_builtins.js
+++ b/extension/framework/runner/test_data/gohan_builtins.js
@@ -55,11 +55,21 @@ function testGohanBuiltins() {
   }
 
   network1.admin_state_up = true;
+  network1.status = 'status0';
   gohan_db_update(transaction, "network", network1);
   var resource = gohan_db_fetch(transaction, "network", "abc", "tenant");
 
   if (JSON.stringify(resource) !== JSON.stringify(network1)) {
-    FAIL("Invalid resource - expected %s, received %s",
+    Fail("Invalid resource - expected %s, received %s",
+        JSON.stringify(network1), JSON.stringify(resource));
+  }
+
+  gohan_db_update_with_nulls(transaction, "network", network1, ["status"]);
+  resource = gohan_db_fetch(transaction, "network", "abc", "tenant");
+  network1.status = undefined;
+
+  if (JSON.stringify(resource) !== JSON.stringify(network1)) {
+    Fail("Invalid resource - expected %s, received %s",
         JSON.stringify(network1), JSON.stringify(resource));
   }
 


### PR DESCRIPTION
Problem:
- Gohan does not allow setting field to null while updating the database

Solutions:
- add builtin which allows setting chosen fields to null (this commit)
- change otto vendor so it allows setting a null value to dictionary instead of removing its key

@nati this problem has two solutions. The second one, however, requires much more work. Could you please let me know which one suits better?