### PR TITLE
[ESI-12189] retry_create_on_duplicate_entry metadata flag

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"github.com/go-sql-driver/mysql"
+	"github.com/mattn/go-sqlite3"
+)
+
+func IsDeadlockError(err error) bool {
+	switch t := err.(type) {
+	case *mysql.MySQLError:
+		switch t.Number {
+		case 1213:
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsDuplicateEntryError(err error) bool {
+	switch t := err.(type) {
+	case *mysql.MySQLError:
+		switch t.Number {
+		case 1062:
+			return true
+		}
+	case sqlite3.Error:
+		switch t.ExtendedCode {
+		case sqlite3.ErrConstraintUnique:
+			return true
+		}
+	}
+
+	return false
+}

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -397,7 +397,7 @@ func (db *DB) genTableCols(s *schema.Schema, cascade bool, exclude []string) ([]
 
 		if property.Indexed {
 			prefix := ""
-			if sqlDataType == "text" {
+			if sqlDataType == "text" && db.sqlType != "sqlite3" {
 				prefix = "(255)"
 			}
 			indices = append(indices, fmt.Sprintf("CREATE INDEX %s_%s_idx ON `%s`(`%s`%s);", s.Plural, property.ID,
@@ -486,7 +486,7 @@ func (db *DB) RegisterTable(s *schema.Schema, cascade, migrate bool) error {
 		return nil
 	}
 	_, err = db.DB.Exec(tableDef)
-	if err != nil && indices != nil {
+	if err == nil && indices != nil {
 		for _, indexSql := range indices {
 			_, err = db.DB.Exec(indexSql)
 			if err != nil {
@@ -512,7 +512,7 @@ func escapeID(ID string) string {
 }
 
 func (tx *Transaction) logQuery(sql string, args ...interface{}) {
-	sqlFormat := strings.Replace(sql, "?", "%s", -1)
+	sqlFormat := strings.Replace(sql, "?", "%v", -1)
 	query := fmt.Sprintf(sqlFormat, args...)
 	log.Debug("[%p] Executing SQL query '%s'", tx.transaction, query)
 }

--- a/db/sql/sql_test.go
+++ b/db/sql/sql_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/schema"
 
+	"github.com/cloudwan/gohan/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -219,16 +220,16 @@ var _ = Describe("Sql", func() {
 		Context("Index on multiple columns", func() {
 			It("Should create unique index on tenant_id and id", func() {
 				_, indices := sqlConn.GenTableDef(test, false)
-				Expect(indices).To(HaveLen(2))
-				Expect(indices[1]).To(ContainSubstring("CREATE UNIQUE INDEX unique_id_and_tenant_id ON `tests`(`id`,`tenant_id`);"))
+				Expect(indices).To(HaveLen(3))
+				Expect(util.ContainsString(indices, "CREATE UNIQUE INDEX unique_id_and_tenant_id ON `tests`(`id`,`tenant_id`);")).To(BeTrue())
 			})
 		})
 
 		Context("Index in schema", func() {
 			It("Should create index, if schema property should be indexed", func() {
 				_, indices := sqlConn.GenTableDef(test, false)
-				Expect(indices).To(HaveLen(2))
-				Expect(indices[0]).To(ContainSubstring("CREATE INDEX tests_tenant_id_idx ON `tests`(`tenant_id`(255));"))
+				Expect(indices).To(HaveLen(3))
+				Expect(util.ContainsString(indices, "CREATE INDEX tests_tenant_id_idx ON `tests`(`tenant_id`);")).To(BeTrue())
 			})
 		})
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -181,6 +181,12 @@ Developers can make a schema as abstract schema specifying type=abstract. The de
   - `skip_related` - locks the resource but leaves related resources unlocked
   - (empty): default, no locking
 
+- retry_create_on_duplicate_entry (boolean)
+
+  Whether create logic should be retried in case of "Duplicate Entry" on DB. Default to false.
+  Useful when pre_create logic is setting some generated data on column where unique index was applied.
+  3 retries are applied to create logic, when flag is turned on.
+
 ## Properties
 
 We need to define properties of a resource using following parameters.

--- a/server/resources/resources_suite_test.go
+++ b/server/resources/resources_suite_test.go
@@ -22,12 +22,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"time"
+
 	"github.com/cloudwan/gohan/db"
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/sync/etcdv3"
 	"github.com/cloudwan/gohan/util"
-	"time"
 )
 
 const (

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -274,6 +274,7 @@ schemas:
   id: test
   metadata:
     state_versioning: true
+    retry_create_on_duplicate_entry: true
   plural: tests
   prefix: /v2.0
   schema:
@@ -281,6 +282,11 @@ schemas:
       unique_id_and_tenant_id:
         columns:
         - id
+        - tenant_id
+        type: "unique"
+      unique_and_test_integer:
+        columns:
+        - test_integer
         - tenant_id
         type: "unique"
     properties:

--- a/util/retry.go
+++ b/util/retry.go
@@ -1,0 +1,11 @@
+package util
+
+func Retry(f func() error, shouldRetry func(error) bool, attempts int) (err error) {
+	for attempt := 0; attempt < attempts; attempt++ {
+		err = f()
+		if !shouldRetry(err) {
+			break
+		}
+	}
+	return
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -69,6 +69,31 @@ var _ = Describe("Util functions", func() {
 			Expect(result).To(Equal([]string{"dolor", "ipsum", "Lorem", "sit"}))
 		})
 	})
+
+	Describe("Retry", func() {
+		var alwaysRetry = func(error) bool { return true }
+		var neverRetry = func(error) bool { return false }
+
+		It("Should retry given number of times", func() {
+			attempts := 3
+			called := 0
+			Retry(func() error {
+				called++
+				return nil
+			}, alwaysRetry, attempts)
+			Expect(called).To(Equal(attempts))
+		})
+
+		It("Should only when given predicate return true", func() {
+			attempts := 3
+			called := 0
+			Retry(func() error {
+				called++
+				return nil
+			}, neverRetry, attempts)
+			Expect(called).To(Equal(1))
+		})
+	})
 })
 
 func testFileUtil(file string) {


### PR DESCRIPTION
Retrying create logic when DB returns 'Duplicate Entry' error.
Useful for logic where some field in resource is generated during pre_create event and unique index is applied to this field.
