### PR TITLE
Wait proper duration for priority in retrying sync watch

### DIFF
--- a/server/sync_watch.go
+++ b/server/sync_watch.go
@@ -156,7 +156,7 @@ func StartSyncWatchProcess(server *Server) {
 								log.Error("Sync Watch on `%s` aborted, retrying...: %s", path, err)
 							}
 
-							backoff := time.NewTimer(time.Second * masterTTL)
+							backoff := time.NewTimer(time.Duration(prio*masterTTL + 1) * time.Second)
 							select {
 							case <-backoff.C:
 							case <-ctx.Done():


### PR DESCRIPTION
Sync watch sometimes fails due to etcd problem. In this case, sync watch
is retried but each process should wait proper duration according to its
priority to watched paths. Currently, retry time is not reflected to its
priority therefore it is very likely for other gohan process to take
over the role of watching sync path regardless of the priority. This
patch makes gohan processes wait properly.