### PR TITLE
ESI-11623 perform locking fetch on Delete operation

### DIFF
--- a/server/transaction_commit_informer.go
+++ b/server/transaction_commit_informer.go
@@ -141,7 +141,7 @@ func (tl *transactionEventLogger) Update(resource *schema.Resource) error {
 }
 
 func (tl *transactionEventLogger) Delete(s *schema.Schema, resourceID interface{}) error {
-	resource, err := tl.Fetch(s, transaction.IDFilter(resourceID))
+	resource, err := tl.Transaction.LockFetch(s, transaction.IDFilter(resourceID), schema.SkipRelatedResources)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
~~Transaction Commit Informer performs a fetch before deleting resource.
In order to have consistency and not race REAPEATABLE_READ view and
READ_COMMITED view when mixing locking and non-locking SELECTS in
SERIALIZABLE transactions.~~

Transaction Commit Informer performs a fetch before deleting resource.
In order to have consistency and not race consistent snapshot with
committed data. E.g:

TX1 is REPEATABLE READ
TX1 Makes some unrelated SELECTS (consistent snapshot established)
TX2 Inserts row X into table test and commits
TX1 SELECTS FOR UPDATE a couple of rows, including newly inserted X
TX1 Decides to DELETE X, but fails with Not Found
    (X doesn't exist in consistent snapshot).
