### PR TITLE
Fixed color output in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ WARN_COLOR=\033[33;01m
 all: gen lint build test
 
 deps:
-	@echo "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Installing dependencies$(NO_COLOR)"
 	./tools/dev_setup.sh
 
 format:
-	@echo "$(OK_COLOR)==> Formatting$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Formatting$(NO_COLOR)"
 
 	govendor fmt +local
 
 gen:
-	@echo "$(OK_COLOR)==> Generating files$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Generating files$(NO_COLOR)"
 	go-bindata -pkg util -o util/bindata.go \
 	etc/schema/... \
 	etc/extensions/... \
@@ -23,17 +23,17 @@ gen:
 	public/...
 
 test:
-	@echo "$(OK_COLOR)==> Testing$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Testing$(NO_COLOR)"
 	./run_test.sh
 
 lint:
-	@echo "$(OK_COLOR)==> Linting$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Linting$(NO_COLOR)"
 	./tools/lint.sh
 
 build: deps
-	@echo "$(OK_COLOR)==> Building$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Building$(NO_COLOR)"
 	./tools/build.sh
 
 install:
-	@echo "$(OK_COLOR)==> Installing$(NO_COLOR)"
+	@echo -e "$(OK_COLOR)==> Installing$(NO_COLOR)"
 	./tools/install.sh


### PR DESCRIPTION
echo does not emit colors by default (at least on arch-linux) so it must be called with parameter -e to see color output