### PR TITLE
ESI-12742 Gohan schema sql tables dont use correct plurals

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,10 @@ Gohan server configuration uses YAML format.
       initial_data:
           - type: "yaml"
             connection: "./etc/examples/heat_template.yaml"
+      # if legacy is true table names are created from schema id,
+      # otherwise table names are based on schema plural,
+      # default true
+      legacy: false
   # schema path
   schemas:
     - "./etc/schema/gohan.json"
@@ -43,7 +47,7 @@ Gohan server configuration uses YAML format.
     cert_file: "./etc/cert.pem"
     key_file: "./etc/key.pem"
   # document root of gohan API server
-  # Note: only static and schema directoriy will be served
+  # Note: only static and schema directory will be served
   document_root: "./etc"
   # list of etcd backend servers
   etcd:

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -323,7 +323,11 @@ func (schema *Schema) GetPluralURLWithParents() string {
 
 // GetDbTableName returns a name of DB table used for storing schema instances
 func (schema *Schema) GetDbTableName() string {
-	return schema.ID + "s"
+	config := util.GetConfig()
+	if config.GetBool("database/legacy", true) {
+		return schema.ID + "s"
+	}
+	return schema.Plural
 }
 
 // GetParentURL returns Parent URL

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -18,11 +18,44 @@ package schema
 import (
 	"fmt"
 
+	"github.com/cloudwan/gohan/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Schema", func() {
+	Describe("Schema plural", func() {
+		var (
+			manager *Manager
+			s       *Schema
+			ok      bool
+		)
+
+		BeforeEach(func() {
+			manager = GetManager()
+			Expect(manager.LoadSchemasFromFiles(
+				"../tests/test_schema_plural.yaml")).To(Succeed())
+
+			s, ok = manager.Schema("box")
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should use schema.ID + \"s\" as table name when legacy is true", func() {
+			Expect(s.GetDbTableName()).To(Equal(s.ID + "s"))
+		})
+
+		It("should use schema.Plural as table name when legacy is false", func() {
+			config := util.GetConfig()
+			config.ReadConfig("../tests/test_legacy_config.yaml")
+			Expect(config.GetBool("database/legacy", true)).To(BeFalse())
+			Expect(s.GetDbTableName()).To(Equal(s.Plural))
+		})
+
+		AfterEach(func() {
+			ClearManager()
+		})
+	})
+
 	Describe("Schema manager", func() {
 		It("should reorder schemas if it is DAG", func() {
 			manager := GetManager()

--- a/tests/test_legacy_config.yaml
+++ b/tests/test_legacy_config.yaml
@@ -1,0 +1,2 @@
+database:
+    legacy: false

--- a/tests/test_schema_plural.yaml
+++ b/tests/test_schema_plural.yaml
@@ -1,0 +1,13 @@
+schemas:
+- description: box
+  id: box
+  singular: box
+  plural: boxes 
+  title: box
+  schema:
+    properties:
+      id:
+        description: ID
+        title: ID
+        type: string
+    type: object


### PR DESCRIPTION
Some tables might have different names if used on existing database. Data will not be lost but new empty tables with correct names will be created.