### PR TITLE
Make sync_watch events sequential for each watch path

### DIFF
--- a/extension/otto/gohan_sync.go
+++ b/extension/otto/gohan_sync.go
@@ -17,9 +17,10 @@ package otto
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/cloudwan/gohan/sync"
 	"github.com/xyproto/otto"
-	"time"
 )
 
 func convertSyncEvent(event *sync.Event) map[string]interface{} {
@@ -73,26 +74,26 @@ func init() {
 					return otto.NullValue()
 				}
 
-				done := make(chan struct{})
+				errCh := make(chan error)
+				defer close(errCh)
 				go func() {
 					node, err = env.Sync.Fetch(path)
-					close(done)
+					errCh <- err
 				}()
 
 				select {
 				case interrupt := <-call.Otto.Interrupt:
 					log.Debug("Received otto interrupt in gohan_sync_fetch")
 					interrupt()
-				case <-done:
-				}
+				case err = <-errCh:
+					if err != nil {
+						ThrowOttoException(&call, "Failed to fetch sync: "+err.Error())
+						return otto.NullValue()
+					}
 
-				if err != nil {
-					ThrowOttoException(&call, "Failed to fetch sync: "+err.Error())
-					return otto.NullValue()
-				}
-
-				if value, err = vm.ToValue(convertSyncNode(node)); err == nil {
-					return value
+					if value, err = vm.ToValue(convertSyncNode(node)); err == nil {
+						return value
+					}
 				}
 
 				return otto.NullValue()
@@ -117,22 +118,58 @@ func init() {
 					return otto.NullValue()
 				}
 
-				done := make(chan struct{})
+				errCh := make(chan error)
+				defer close(errCh)
 				go func() {
 					err = env.Sync.Delete(path, prefix)
-					close(done)
+					errCh <- err
 				}()
 
 				select {
 				case interrupt := <-call.Otto.Interrupt:
 					log.Debug("Received otto interrupt in gohan_sync_delete")
 					interrupt()
-				case <-done:
+				case err = <-errCh:
+					if err != nil {
+						ThrowOttoException(&call, "Failed to delete sync: "+err.Error())
+						return otto.NullValue()
+					}
 				}
 
-				if err != nil {
-					ThrowOttoException(&call, "Failed to delete sync: "+err.Error())
+				return otto.NullValue()
+			},
+			"gohan_sync_update": func(call otto.FunctionCall) otto.Value {
+				var path string
+				var value string
+				var err error
+
+				VerifyCallArguments(&call, "gohan_sync_update", 2)
+
+				if path, err = GetString(call.Argument(0)); err != nil {
+					ThrowOttoException(&call, "Invalid type of first argument: expected a string")
 					return otto.NullValue()
+				}
+				if value, err = GetString(call.Argument(1)); err != nil {
+					ThrowOttoException(&call, "Invalid type of second argument: expected a string")
+					return otto.NullValue()
+				}
+
+				errCh := make(chan error)
+				defer close(errCh)
+				go func() {
+					err = env.Sync.Update(path, value)
+					errCh <- err
+				}()
+
+				select {
+				case interrupt := <-call.Otto.Interrupt:
+					log.Debug("Received otto interrupt in gohan_sync_update")
+					interrupt()
+				case err = <-errCh:
+					if err != nil {
+						ThrowOttoException(&call, "Failed to update sync: "+err.Error())
+						return otto.NullValue()
+					}
 				}
 
 				return otto.NullValue()

--- a/server/server.go
+++ b/server/server.go
@@ -19,10 +19,21 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/braintree/manners"
 	"github.com/cloudwan/gohan/db"
 	"github.com/cloudwan/gohan/db/migration"
-
 	"github.com/cloudwan/gohan/db/options"
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension"
@@ -38,17 +49,6 @@ import (
 	"github.com/go-martini/martini"
 	"github.com/lestrrat/go-server-starter/listener"
 	"github.com/martini-contrib/staticbin"
-	"net"
-	"net/http"
-	"net/http/pprof"
-	"os"
-	"os/signal"
-	"path"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"syscall"
-	"time"
 )
 
 type tlsConfig struct {
@@ -511,7 +511,7 @@ func RunServer(configFile string) {
 			}
 			extensions[event] = env
 		}
-		syncWatcher := NewSyncWatcher(server.sync, server.queue, keys, events, extensions)
+		syncWatcher := NewSyncWatcher(server.sync, keys, events, extensions)
 		go syncWatcher.Run(server.masterCtx)
 
 	}

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -7,6 +7,7 @@ schemas:
     - "../tests/test_schema.yaml"
     - "../tests/test_schema_sync.yaml"
     - "../tests/test_two_same_relations_schema.yaml"
+    - "../tests/test_sync_watch_extension.yaml"
 address: ":19090"
 document_root: "embed"
 sync: etcdv3

--- a/tests/sync_watch_extension.js
+++ b/tests/sync_watch_extension.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Sample Gohan Extension
+
+// You need to register event handler
+
+gohan_register_handler("notification", function(context){
+  var currentDate = Date.now();
+  var writePath = "/test/" + currentDate;
+  gohan_sync_update(writePath, context.key);
+
+  // wait 5 sec
+  gohan_sleep(5000);
+});

--- a/tests/test_sync_watch_extension.yaml
+++ b/tests/test_sync_watch_extension.yaml
@@ -1,0 +1,4 @@
+extensions:
+- id: test_sync_watch
+  path: .*
+  url: file://../tests/sync_watch_extension.js


### PR DESCRIPTION
Previously, sync_watcher hooked notification events as soon as it detects
sync states for watching path. That makes multiple events for the same
path can happen in very short time slot, so this makes it difficult to
avoid race problem.

This feature was introduced by gohan's internal task queue which allows
parallelism. By simply avoiding to use this queue to execute task, gohan
can assure sequential event notifications for each sync path.

Additionally, this patch introduces JS builtin gohan_sync_update. This
builtin is used in sync_watcher_test, but that should be general feature
like gohan_sync_fetch or gohan_sync_delete.