### PR TITLE
ESI-10451 Gohan client custom actions improvements

### DIFF
--- a/cli/client/arguments_test.go
+++ b/cli/client/arguments_test.go
@@ -1,0 +1,279 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	l "github.com/cloudwan/gohan/log"
+	"github.com/cloudwan/gohan/schema"
+	"strings"
+)
+
+const (
+	parsingError = "Error parsing parameter '%v': %v"
+)
+
+func getBoolAction() schema.Action {
+	return schema.NewAction(
+		"BoolAction",
+		"GET",
+		"/bool/",
+		"action with input type bool",
+		map[string]interface{}{
+			"type": "boolean",
+		},
+		nil,
+		nil,
+	)
+}
+
+func getObjectAction() schema.Action {
+	return schema.NewAction(
+		"ObjectAction",
+		"GET",
+		"/object/",
+		"action with input type object",
+		map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"a": map[string]interface{}{
+					"type": "number",
+				},
+				"b": map[string]interface{}{
+					"type": "boolean",
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+}
+
+var _ = Describe("Arguments", func() {
+	Describe("Parsing raw value", func() {
+		It("Should parse null", func() {
+			value, err := getValueFromRaw("", "<null>", "")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(value).To(BeNil())
+		})
+
+		It("Should show error for invalid integer", func() {
+			key := "Key"
+			_, err := getValueFromRaw(key, "a", "number")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(parsingError, key, "strconv.ParseInt: parsing \"a\": invalid syntax")))
+		})
+
+		It("Should parse valid integer", func() {
+			value, err := getValueFromRaw("", "1", "number")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(value).To(Equal(int64(1)))
+		})
+
+		It("Should show error for invalid boolean", func() {
+			key := "Key"
+			_, err := getValueFromRaw(key, "a", "boolean")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(parsingError, key, "strconv.ParseBool: parsing \"a\": invalid syntax")))
+		})
+
+		It("Shoud parse valid boolean", func() {
+			value, err := getValueFromRaw("", "true", "boolean")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(value).To(BeTrue())
+		})
+
+		It("Should show error for invalid json", func() {
+			key := "Key"
+			_, err := getValueFromRaw(key, "a", "object")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(parsingError, key, "invalid character 'a' looking for beginning of value")))
+		})
+
+		It("Should parse valid json", func() {
+			var expected = map[string]interface{}{
+				"a": 1.0,
+				"b": true,
+			}
+			data, err := getValueFromRaw("", "{\"a\": 1, \"b\": true}", "object")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(data).To(Equal(expected))
+		})
+	})
+
+	Describe("Tests with gohan client", func() {
+		var gohanClientCLI GohanClientCLI
+
+		BeforeEach(func() {
+			gohanClientCLI = GohanClientCLI{opts: &GohanClientCLIOpts{}}
+		})
+
+		Describe("Handling common arguments", func() {
+			const (
+				outputFormatKey = "output-format"
+				logLevelKey     = "verbosity"
+				fieldsKey       = "fields"
+			)
+
+			var (
+				outputFormats = []string{"table", "json"}
+				logLevels     = []l.Level{
+					l.WARNING,
+					l.NOTICE,
+					l.INFO,
+					l.DEBUG,
+				}
+			)
+
+			It("Should show output format error", func() {
+				args := map[string]interface{}{outputFormatKey: "number"}
+				err := gohanClientCLI.handleCommonArguments(args)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Sprintf(incorrectOutputFormat, outputFormats)))
+			})
+
+			It("Should show log level error", func() {
+				args := map[string]interface{}{logLevelKey: "a"}
+				err := gohanClientCLI.handleCommonArguments(args)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(fmt.Sprintf(incorrectVerbosityLevel, 0, len(logLevels)-1)))
+			})
+
+			It("Should show handle common args", func() {
+				fields := "a,b,c"
+				args := map[string]interface{}{
+					outputFormatKey: "table",
+					logLevelKey:     "0",
+					fieldsKey:       fields,
+				}
+				err := gohanClientCLI.handleCommonArguments(args)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gohanClientCLI.opts.outputFormat).To(Equal("table"))
+				Expect(args[outputFormatKey]).To(BeNil())
+				Expect(gohanClientCLI.opts.logLevel).To(Equal(l.WARNING))
+				Expect(args[logLevelKey]).To(BeNil())
+				Expect(gohanClientCLI.opts.fields).To(Equal(strings.Split(fields, ",")))
+				Expect(args[fieldsKey]).To(BeNil())
+			})
+
+			Describe("Getting arguments", func() {
+				const invalidFormat = "Parameters should be in [--param-name value]... format"
+
+				var schema schema.Schema = schema.Schema{Properties: []schema.Property{
+					{ID: "a", Type: "boolean"},
+					{ID: "b", Type: "number"},
+				}}
+
+				It("Shoud show error for invalid parameters format", func() {
+					_, err := getArgsAsMap([]string{"a", "b", "c"}, &schema)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(invalidFormat))
+				})
+
+				It("Shoud show parsing error", func() {
+					_, err := getArgsAsMap([]string{"--a", "a"}, &schema)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(fmt.Sprintf(parsingError, "a", "strconv.ParseBool: parsing \"a\": invalid syntax")))
+				})
+
+				It("Should get correct arguments map", func() {
+					var text = "[\"a\", \"b\"]"
+					data, err := getArgsAsMap([]string{"--a", "false", "--b", "2", "--c", "<null>", "--d", text}, &schema)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(data["a"]).To(BeFalse())
+					Expect(data["b"]).To(Equal(int64(2)))
+					Expect(data["c"]).To(BeNil())
+					Expect(data["d"]).To(Equal(text))
+				})
+			})
+
+			Describe("Getting custom arguments", func() {
+
+				It("Should show error for incorrect input type", func() {
+					_, err := gohanClientCLI.getCustomArgsAsMap(nil, []string{"a"}, getBoolAction())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(fmt.Sprintf(parsingError, "input", "strconv.ParseBool: parsing \"a\": invalid syntax")))
+				})
+
+				It("Should get arguments map with correct input", func() {
+					action := getBoolAction()
+					data, err := gohanClientCLI.getCustomArgsAsMap(nil, []string{"false"}, action)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(data[action.ID]).To(BeFalse())
+				})
+
+				It("Shoud show error for many input arguments when type is not object", func() {
+					_, err := gohanClientCLI.getCustomArgsAsMap(nil, []string{"true", "false"}, getBoolAction())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("Input schema type must be an object to pass input with parameters"))
+				})
+
+				It("Should show error for non existing parameter", func() {
+					_, err := gohanClientCLI.getCustomArgsAsMap(nil, []string{"--c", "false"}, getObjectAction())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("Property with ID c not found"))
+				})
+
+				It("Should show error for invalid parameter value", func() {
+					_, err := gohanClientCLI.getCustomArgsAsMap(nil, []string{"--a", "b"}, getObjectAction())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(fmt.Sprintf(parsingError, "a", "strconv.ParseInt: parsing \"b\": invalid syntax")))
+				})
+
+				It("Should show error for invalid common parameter", func() {
+					_, err := gohanClientCLI.getCustomArgsAsMap([]string{"--a", "b"}, []string{"false"}, getBoolAction())
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError("Error parsing parameter a"))
+				})
+
+				Describe("Correct input", func() {
+					var (
+						expected = map[string]interface{}{
+							"a": int64(1),
+							"b": true,
+						}
+						action = getObjectAction()
+					)
+
+					It("Should get argumets map with correct input - many parameters", func() {
+						data, err := gohanClientCLI.getCustomArgsAsMap(
+							[]string{"--output-format", "table"},
+							[]string{"--a", "1", "--b", "true"},
+							action)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(data[action.ID]).To(Equal(expected))
+						Expect(data["output-format"]).To(BeNil())
+						Expect(gohanClientCLI.opts.outputFormat).To(Equal("table"))
+					})
+
+					It("Should get arguments map with correct input - one parameter", func() {
+						data, err := gohanClientCLI.getCustomArgsAsMap(
+							[]string{"--output-format", "table"},
+							[]string{"{\"a\": 1, \"b\": true}"},
+							action)
+						Expect(err).ToNot(HaveOccurred())
+						expected["a"] = 1.0
+						Expect(data[action.ID]).To(Equal(expected))
+						Expect(gohanClientCLI.opts.outputFormat).To(Equal("table"))
+					})
+				})
+			})
+		})
+	})
+})

--- a/cli/client/client_test_utils.go
+++ b/cli/client/client_test_utils.go
@@ -237,11 +237,107 @@ func getChamberSchema() map[string]interface{} {
 	}
 }
 
+func getActionsSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"description": "Action",
+		"id":          "action",
+		"title":       "action",
+		"singular":    "action",
+		"plural":      "action",
+		"prefix":      "/v2.0",
+		"url":         "/v2.0/actions",
+		"schema": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"a": map[string]interface{}{
+					"permission": []interface{}{
+						"create",
+						"update",
+					},
+					"type": "number",
+				},
+				"b": map[string]interface{}{
+					"permission": []interface{}{
+						"create",
+						"update",
+					},
+					"type": "boolean",
+				},
+				"c": map[string]interface{}{
+					"permission": []interface{}{
+						"create",
+						"update",
+					},
+					"type": "string",
+				},
+				"d": map[string]interface{}{
+					"permission": []interface{}{
+						"create",
+						"update",
+					},
+					"type": "object",
+				},
+			},
+			"propertiesOrder": []interface{}{
+				"a",
+				"b",
+				"c",
+				"d",
+			},
+		},
+		"actions": map[string]interface{}{
+			"do_a": map[string]interface{}{
+				"method": "GET",
+				"path":   "/do_a",
+				"output": map[string]interface{}{
+					"type": "string",
+				},
+			},
+			"do_b": map[string]interface{}{
+				"method": "GET",
+				"path":   "/:id/do_b",
+			},
+			"do_c": map[string]interface{}{
+				"method": "GET",
+				"path":   "/do_c",
+				"input": map[string]interface{}{
+					"type": "number",
+				},
+			},
+			"do_d": map[string]interface{}{
+				"method": "GET",
+				"path":   "/:id/do_d",
+				"input": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"a_in": map[string]interface{}{
+							"type": "number",
+						},
+						"b_in": map[string]interface{}{
+							"type": "string",
+						},
+						"c_in": map[string]interface{}{
+							"type": "boolean",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func getSchemasResponse() interface{} {
 	return map[string]interface{}{
 		"schemas": []map[string]interface{}{
 			getCastleSchema(),
 			getTowerSchema(),
+		},
+	}
+}
+
+func getActionSchemasResponse() interface{} {
+	return map[string]interface{}{
+		"schemas": []map[string]interface{}{
+			getActionsSchema(),
 		},
 	}
 }
@@ -270,6 +366,10 @@ func openGates() string {
 
 func closeGates() string {
 	return "gates closed"
+}
+
+func doA() string {
+	return "done a"
 }
 
 func getIcyTower() map[string]interface{} {
@@ -313,8 +413,8 @@ func compareSchemas(actual, expected []*schema.Schema) {
 	for i, s := range actual {
 		sortProperties(s)
 		sortProperties(expected[i])
-		sortActions(s)
-		sortActions(expected[i])
+		schema.SortActions(s)
+		schema.SortActions(expected[i])
 		g.Expect(s).To(g.Equal(expected[i]))
 	}
 }
@@ -327,16 +427,6 @@ func (p properties) Less(i, j int) bool { return p[i].ID < p[j].ID }
 
 func sortProperties(schema *schema.Schema) {
 	sort.Sort(properties(schema.Properties))
-}
-
-type actions []schema.Action
-
-func (a actions) Len() int           { return len(a) }
-func (a actions) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a actions) Less(i, j int) bool { return a[i].ID < a[j].ID }
-
-func sortActions(schema *schema.Schema) {
-	sort.Sort(actions(schema.Actions))
 }
 
 //ByName is alias type for handling gohanCommands

--- a/cli/client/commands_test.go
+++ b/cli/client/commands_test.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"github.com/cloudwan/gohan/schema"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func idAction() schema.Action {
+	return schema.NewAction(
+		"IdAction",
+		"GET",
+		"/id/:id/",
+		"action with id",
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func inputAction() schema.Action {
+	return schema.NewAction(
+		"InputAction",
+		"GET",
+		"/input/",
+		"action with input",
+		map[string]interface{}{
+			"type": "boolean",
+		},
+		nil,
+		nil,
+	)
+}
+
+func idInputAction() schema.Action {
+	return schema.NewAction(
+		"IdInputAction",
+		"GET",
+		"/input/:id/",
+		"action with input and id",
+		map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"a": map[string]interface{}{
+					"type": "boolean",
+				},
+				"b": map[string]interface{}{
+					"type": "number",
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+}
+
+var _ = Describe("Commands", func() {
+	Describe("Split arguments", func() {
+		const (
+			argumentsError    = "Wrong number of arguments"
+			noPropertiesError = "Input schema does not have properties"
+		)
+
+		var (
+			idAction      = idAction()
+			inputAction   = inputAction()
+			idInputAction = idInputAction()
+		)
+
+		It("Should show error for wrong number of arguments - id", func() {
+			_, _, _, err := splitArgs([]string{}, &idAction)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(argumentsError))
+		})
+
+		It("Should show error for wrong number of arguments - input", func() {
+			_, _, _, err := splitArgs([]string{}, &inputAction)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(argumentsError))
+		})
+
+		It("Should show error for wrong number of arguments - id and input", func() {
+			_, _, _, err := splitArgs([]string{}, &idInputAction)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(argumentsError))
+		})
+
+		It("Should show error for input with no properties", func() {
+			_, _, _, err := splitArgs([]string{"a", "b"}, &inputAction)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noPropertiesError))
+		})
+
+		It("Should get correct arguments - multiple arguments", func() {
+			args, input, id, err := splitArgs([]string{"1", "2", "3", "4", "5", "6", "7"}, &idInputAction)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(args).To(Equal([]string{"1", "2"}))
+			Expect(input).To(Equal([]string{"3", "4", "5", "6"}))
+			Expect(id).To(Equal("7"))
+		})
+
+		It("Should get correct arguments - one argument", func() {
+			args, input, id, err := splitArgs([]string{"1", "2"}, &idInputAction)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(args).To(Equal([]string{}))
+			Expect(input).To(Equal([]string{"1"}))
+			Expect(id).To(Equal("2"))
+		})
+	})
+})

--- a/schema/action_test.go
+++ b/schema/action_test.go
@@ -1,0 +1,290 @@
+// Copyright (C) 2015 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sort"
+)
+
+func getData(data map[string]interface{}) ([]string, []interface{}) {
+	keys := make([]string, len(data))
+	values := make([]interface{}, len(data))
+	i := 0
+	for k, v := range data {
+		keys[i] = k
+		values[i] = v
+		i++
+	}
+	return keys, values
+}
+
+func emptyAction() Action {
+	return NewAction(
+		"empty",
+		"GET",
+		"/empty/",
+		"empty action",
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func noInputTypeAction() Action {
+	return NewAction(
+		"noInputType",
+		"GET",
+		"/noInputType/:id/",
+		"action with no input type",
+		map[string]interface{}{
+			"properties": map[string]interface{}{
+				"a": map[string]interface{}{
+					"type": "number",
+				},
+				"b": "no map",
+			},
+		},
+		nil,
+		nil,
+	)
+}
+
+func invalidInputTypeAction() Action {
+	return NewAction(
+		"invalidInputType",
+		"GET",
+		"/invalidType",
+		"action with invalid input type",
+		map[string]interface{}{
+			"type": struct{}{},
+		},
+		nil,
+		nil,
+	)
+}
+
+func invalidPropertiesType() Action {
+	return NewAction(
+		"invalidPropertiesType",
+		"GET",
+		"/invalidPropertiesType/",
+		"action with invalid input properties type",
+		map[string]interface{}{
+			"type":       "object",
+			"properties": "abc",
+		},
+		nil,
+		nil,
+	)
+}
+
+func invalidProperties() Action {
+	return NewAction(
+		"invalidProperties",
+		"GET",
+		"/invalidProperties/",
+		"action with invalid input properties",
+		map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"a": "null",
+				"b": map[string]interface{}{
+					"test": "null",
+				},
+				"c": map[string]interface{}{
+					"type": struct{}{},
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+}
+
+func validAction() Action {
+	return NewAction(
+		"validAction",
+		"GET",
+		"/valid/:id/action/",
+		"valid action",
+		map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"a": map[string]interface{}{
+					"type": "number",
+				},
+				"b": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"1": map[string]interface{}{
+							"type": "string",
+						},
+						"2": map[string]interface{}{
+							"type": "boolean",
+						},
+					},
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+}
+
+var _ = Describe("Action", func() {
+	const (
+		noInputError         = "Action does not take input"
+		noPropertiesError    = "Input schema does not have properties"
+		noInputTypeError     = "Input schema does not have a type"
+		notFoundError        = "Property with ID %s not found"
+		noParameterTypeError = "Parameter with ID %s does not have a type"
+	)
+
+	var (
+		empty                 Action
+		noInputType           Action
+		invalidInputType      Action
+		invalidParametersType Action
+		invalidParameters     Action
+		valid                 Action
+	)
+
+	BeforeEach(func() {
+		empty = emptyAction()
+		noInputType = noInputTypeAction()
+		invalidInputType = invalidInputTypeAction()
+		invalidParametersType = invalidPropertiesType()
+		invalidParameters = invalidProperties()
+		valid = validAction()
+	})
+
+	Describe("id in Path", func() {
+		It("Should check if action takes an id a as parameter", func() {
+			Expect(empty.TakesID()).To(BeFalse())
+			Expect(noInputType.TakesID()).To(BeTrue())
+			Expect(invalidInputType.TakesID()).To(BeFalse())
+			Expect(invalidParametersType.TakesID()).To(BeFalse())
+			Expect(invalidParameters.TakesID()).To(BeFalse())
+			Expect(valid.TakesID()).To(BeTrue())
+		})
+	})
+
+	Describe("input type", func() {
+		It("Should show error for action with no input", func() {
+			_, err := empty.GetInputType()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noInputError))
+		})
+
+		It("Should show error for action with no input type", func() {
+			_, err := noInputType.GetInputType()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noInputTypeError))
+		})
+
+		It("Should show error for action with invalid input type", func() {
+			_, err := invalidInputType.GetInputType()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noInputTypeError))
+		})
+
+		It("Should show correct type for action with valid type", func() {
+			result, err := invalidParameters.GetInputType()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(invalidParameters.InputSchema["type"]))
+		})
+	})
+
+	Describe("input parameter names", func() {
+		It("Should show error for action with no input", func() {
+			_, err := empty.GetInputParameterNames()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noInputError))
+		})
+
+		It("Should show error for action with no properties", func() {
+			_, err := invalidInputType.GetInputParameterNames()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noPropertiesError))
+		})
+
+		It("Should show error for action with invalid properties type", func() {
+			_, err := invalidParametersType.GetInputParameterNames()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noPropertiesError))
+		})
+
+		It("Should get input parameter names for valid action", func() {
+			result, err := valid.GetInputParameterNames()
+			Expect(err).ToNot(HaveOccurred())
+			keys, _ := getData(valid.InputSchema["properties"].(map[string]interface{}))
+			sort.Strings(result)
+			sort.Strings(keys)
+			Expect(result).To(Equal(keys))
+		})
+	})
+
+	Describe("input parameter types", func() {
+		It("Should show error for action with no input", func() {
+			_, err := empty.GetInputParameterType("a")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noInputError))
+		})
+
+		It("Should show error for action with no properties", func() {
+			_, err := invalidInputType.GetInputParameterType("a")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(noPropertiesError))
+		})
+
+		It("Should show error for non existing parameter", func() {
+			_, err := valid.GetInputParameterType("c")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(notFoundError, "c")))
+		})
+
+		It("Should show error for invalid parameter", func() {
+			_, err := invalidParameters.GetInputParameterType("a")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(notFoundError, "a")))
+		})
+
+		It("Should show error for parameter with no type", func() {
+			_, err := invalidParameters.GetInputParameterType("b")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(noParameterTypeError, "b")))
+		})
+
+		It("Should show error for parameter with invalid type", func() {
+			_, err := invalidParameters.GetInputParameterType("c")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf(noParameterTypeError, "c")))
+		})
+
+		It("Should get correct parameter type", func() {
+			properties := valid.InputSchema["properties"].(map[string]interface{})
+			result, err := valid.GetInputParameterType("a")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(properties["a"].(map[string]interface{})["type"]))
+			result, err = valid.GetInputParameterType("b")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(properties["b"].(map[string]interface{})["type"]))
+		})
+	})
+})

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -652,3 +652,13 @@ func (schema *Schema) GetLockingPolicy(event string) LockPolicy {
 		panic(fmt.Sprintf("Unknown locking policy '%s' for event %s in schema %s", policy, event, schema.ID))
 	}
 }
+
+// GetActionFromCommand gets action with given id
+func (schema *Schema) GetActionFromCommand(command string) *Action {
+	for _, action := range schema.Actions {
+		if action.ID == command {
+			return &action
+		}
+	}
+	return nil
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -56,6 +56,31 @@ var _ = Describe("Schema", func() {
 		})
 	})
 
+	Describe("Action", func() {
+		var manager *Manager
+
+		BeforeEach(func() {
+			manager = GetManager()
+			Expect(manager.LoadSchemasFromFiles("../tests/test_schema_action.yaml")).To(Succeed())
+		})
+
+		It("Should get nil for non existing action", func() {
+			s, ok := manager.schema("action")
+			Expect(ok).To(BeTrue())
+			Expect(s.GetActionFromCommand("b")).To(BeNil())
+		})
+
+		It("Should get correct action", func() {
+			s, ok := manager.schema("action")
+			Expect(ok).To(BeTrue())
+			Expect(s.GetActionFromCommand("a")).To(Equal(&s.Actions[0]))
+		})
+
+		AfterEach(func() {
+			ClearManager()
+		})
+	})
+
 	Describe("Schema manager", func() {
 		It("should reorder schemas if it is DAG", func() {
 			manager := GetManager()

--- a/tests/test_schema_action.yaml
+++ b/tests/test_schema_action.yaml
@@ -1,0 +1,17 @@
+schemas:
+- description: action
+  id: action
+  singular: action
+  plural: actions
+  title: action
+  schema:
+    properties:
+      id:
+        description: ID
+        title: ID
+        type: string
+    type: object
+  actions:
+    a:
+      method: GET
+      path: /a


### PR DESCRIPTION
Custom actions with parameters are now displayed when inspecting resource:

gohan client resource

Custom action parameters are now displayed when inspecting action that takes at least one parameter (action with no id in path and no input schema will be executed):
gohan client resource action

When input type is object input can be passed either by --parameter_name value or by json:
gohan client resource action input -> json
gohan client resource action --parameter-name1 --value1 ... -> parameters

More verbose errors for invalid custom action input