### PR TITLE
[ESI-13782] Watch() should not skip values when asked for a specific revision

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,9 +9,9 @@ machine:
 
 dependencies:
   override:
-    - curl -L https://github.com/coreos/etcd/releases/download/v3.0.15/etcd-v3.0.15-linux-amd64.tar.gz -o etcd-v3.0.15-linux-amd64.tar.gz
-    - tar xzvf etcd-v3.0.15-linux-amd64.tar.gz
-    - sudo install etcd-v3.0.15-linux-amd64/etcd /usr/bin
+    - curl -L https://github.com/coreos/etcd/releases/download/v3.1.7/etcd-v3.1.7-linux-amd64.tar.gz -o etcd-v3.1.7-linux-amd64.tar.gz
+    - tar xzvf etcd-v3.1.7-linux-amd64.tar.gz
+    - sudo install etcd-v3.1.7-linux-amd64/etcd /usr/bin
     - go get github.com/mattn/goveralls
     - make deps
 

--- a/server/sync_watcher.go
+++ b/server/sync_watcher.go
@@ -89,7 +89,6 @@ func NewSyncWatcherFromServer(server *Server) *SyncWatcher {
 func (watcher *SyncWatcher) Run(ctx context.Context) error {
 	for {
 		err := func() error {
-			fromRevision := int64(gohan_sync.RevisionCurrent)
 			// register self process to the cluster
 			lockKey := processPathPrefix + "/" + watcher.sync.GetProcessID()
 			lost, err := watcher.sync.Lock(lockKey, true)
@@ -99,7 +98,7 @@ func (watcher *SyncWatcher) Run(ctx context.Context) error {
 			defer watcher.sync.Unlock(lockKey)
 
 			watchCtx, watchCancel := context.WithCancel(ctx)
-			events, err := watcher.sync.WatchContext(watchCtx, processPathPrefix, fromRevision)
+			events, err := watcher.sync.WatchContext(watchCtx, processPathPrefix, int64(gohan_sync.RevisionCurrent))
 			if err != nil {
 				return err
 			}
@@ -258,7 +257,7 @@ func (watcher *SyncWatcher) processSyncWatch(ctx context.Context, path string) e
 	defer watcher.sync.Unlock(lockKey)
 
 	watchCtx, watchCancel := context.WithCancel(ctx)
-	fromRevision := watcher.fetchStoredRevision(path)
+	fromRevision := watcher.fetchStoredRevision(path) + 1
 	respCh, err := watcher.sync.WatchContext(watchCtx, path, fromRevision)
 	if err != nil {
 		return err

--- a/sync/etcdv3/etcd.go
+++ b/sync/etcdv3/etcd.go
@@ -265,7 +265,7 @@ func eventsFromNode(action string, kvs []*pb.KeyValue, responseChan chan *sync.E
 func (s *Sync) Watch(path string, responseChan chan *sync.Event, stopChan chan bool, revision int64) error {
 	options := []etcd.OpOption{etcd.WithPrefix(), etcd.WithSort(etcd.SortByModRevision, etcd.SortAscend)}
 	if revision != sync.RevisionCurrent {
-		options = append(options, etcd.WithMinModRev(revision+1))
+		options = append(options, etcd.WithMinModRev(revision))
 	}
 	node, err := s.etcdClient.Get(s.withTimeout(), path, options...)
 	if err != nil {

--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -288,7 +288,7 @@ func TestWatchWithRevision(t *testing.T) {
 func newSync(t *testing.T) *Sync {
 	sync, err := NewSync(endpoints, time.Millisecond*100)
 	if err != nil {
-		t.Errorf("unexpected error")
+		t.Fatalf("unexpected error: %s", err)
 	}
 	return sync
 }

--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -209,7 +209,7 @@ func TestWatch(t *testing.T) {
 	sync := newSync(t)
 	sync.etcdClient.Delete(context.Background(), "/", etcd.WithPrefix())
 
-	path := "/path/to/watch"
+	path := "/path/to/watch/without/revision"
 	responseChan := make(chan *gohan_sync.Event)
 	stopChan := make(chan bool)
 
@@ -238,6 +238,51 @@ func TestWatch(t *testing.T) {
 	if resp.Action != "delete" || resp.Key != path+"/existing" || len(resp.Data) != 0 {
 		t.Errorf("mismatch response: %+v", resp)
 	}
+}
+
+func TestWatchWithRevision(t *testing.T) {
+	sync := newSync(t)
+	sync.etcdClient.Delete(context.Background(), "/", etcd.WithPrefix())
+
+	path := "/path/to/watch/with/revision"
+	responseChan := make(chan *gohan_sync.Event)
+	stopChan := make(chan bool)
+
+	putResponse, err := sync.etcdClient.Put(context.Background(), path+"/existing", `{"existing": true}`)
+	if err != nil {
+		t.Fatalf("failed to put key: %s", err)
+	}
+	startRev := putResponse.Header.Revision
+
+	putResponse, err = sync.etcdClient.Put(context.Background(), path+"/new", `{"existing": false}`)
+	if err != nil {
+		t.Fatalf("failed to update key: %s", err)
+	}
+	secondRevision := putResponse.Header.Revision
+
+	go func() {
+		err := sync.Watch(path, responseChan, stopChan, startRev+1)
+		if err != nil {
+			t.Fatalf("failed to watch")
+		}
+	}()
+
+	resp := <-responseChan
+	if resp.Key != path+"/new" || resp.Data["existing"].(bool) != false || resp.Revision != secondRevision{
+		t.Fatalf("mismatch response: %+v, expecting /new, existing==false, revision==%d", resp, secondRevision)
+	}
+
+	putResponse, err = sync.etcdClient.Put(context.Background(), path+"/third", `{"existing": false}`)
+	if err != nil {
+		t.Fatalf("failed to update key: %s", err)
+	}
+	thirdRevision := putResponse.Header.Revision
+
+	resp = <-responseChan
+	if resp.Key != path+"/third" || resp.Data["existing"].(bool) != false || resp.Revision != thirdRevision{
+		t.Fatalf("mismatch response: %+v, expecting /third, existing==false, revision==%d", resp, thirdRevision)
+	}
+
 }
 
 func newSync(t *testing.T) *Sync {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -35,9 +35,9 @@ type Sync interface {
 	Delete(path string, prefix bool) error
 	// Watch monitors changes on path and emits Events to responseChan.
 	// Close stopChan to cancel.
-	// You can specify the reivision to start watching,
-	// give ReivisionCurrent when you want to start from the current reivision.
-	// Returnes an error when gets any error including connection failures.
+	// You can specify the revision to start watching,
+	// give RevisionCurrent when you want to start from the current revision.
+	// Returns an error when gets any error including connection failures.
 	Watch(path string, responseChan chan *Event, stopChan chan bool, revision int64) error
 	//WatchContext keep watch update under the path until context is canceled.
 	WatchContext(ctx context.Context, path string, revision int64) (<-chan *Event, error)


### PR DESCRIPTION
This PR fixes a situation when, for a specific key, there are revision r1, r2 and r3. When Watch() was called with r1, it will not report r2 in the results, but skip directly to r3 (and future revisions).