### PR TITLE
[ESI-13437] Gohan - concurrent map writes error

### DIFF
--- a/schema/manager.go
+++ b/schema/manager.go
@@ -508,15 +508,14 @@ func (manager *Manager) ClearExtensions() {
 }
 
 var (
-	gohanFormatsRegistered bool
+	gohanFormatsRegisteredOnce sync.Once
 )
 
 //GetManager get manager
 func GetManager() *Manager {
-	if !gohanFormatsRegistered {
+	gohanFormatsRegisteredOnce.Do(func() {
 		registerGohanFormats(gojsonschema.FormatCheckers)
-		gohanFormatsRegistered = true
-	}
+	})
 
 	return singleton.Get("schema/manager", func() interface{} {
 		return &Manager{


### PR DESCRIPTION
When parallel tests are starting, registerGohanFormats was incorrectly synchronized thus causing concurrent writes in gojsonschema library. The fix is to use sync.Once instead of plain bool flag.