### PR TITLE
ESI-13857 Clear lint/vet warnings in gohan

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/framework"
 	"github.com/cloudwan/gohan/extension/gohanscript"
+	// Import gohan extension autogen lib
 	_ "github.com/cloudwan/gohan/extension/gohanscript/autogen"
 	"github.com/cloudwan/gohan/extension/otto"
 	l "github.com/cloudwan/gohan/log"
@@ -412,21 +413,21 @@ func getMigrateSubcommand(subcmd, usage string) cli.Command {
 
 func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command {
 	const (
-		POST_MIGRATION_EVENT_TIMEOUT_FLAG = "post-migration-event-timeout"
-		CONFIG_FILE_FLAG                  = "config-file"
-		EMIT_POST_MIGRATION_EVENT_FLAG    = "emit-post-migration-event"
-		POST_MIGRATION_EVENT              = "post-migration"
+		PostMigrationEventTimeoutFlag = "post-migration-event-timeout"
+		ConfigFileFlag                = "config-file"
+		EmitPostMigrationEventFlag    = "emit-post-migration-event"
+		PostMigrationEvent            = "post-migration"
 	)
 	return cli.Command{
 		Name:  subcmd,
 		Usage: usage,
 		Flags: []cli.Flag{
-			cli.StringFlag{Name: CONFIG_FILE_FLAG, Value: defaultConfigFile, Usage: "Server config File"},
-			cli.BoolFlag{Name: EMIT_POST_MIGRATION_EVENT_FLAG, Usage: "Enable if post-migration event should be emited to modified schema extensions"},
-			cli.DurationFlag{Name: POST_MIGRATION_EVENT_TIMEOUT_FLAG, Value: time.Second * 30, Usage: "Maximum duration of post-migration event"},
+			cli.StringFlag{Name: ConfigFileFlag, Value: defaultConfigFile, Usage: "Server config File"},
+			cli.BoolFlag{Name: EmitPostMigrationEventFlag, Usage: "Enable if post-migration event should be emited to modified schema extensions"},
+			cli.DurationFlag{Name: PostMigrationEventTimeoutFlag, Value: time.Second * 30, Usage: "Maximum duration of post-migration event"},
 		},
 		Action: func(context *cli.Context) {
-			configFile := context.String(CONFIG_FILE_FLAG)
+			configFile := context.String(ConfigFileFlag)
 			if migration.LoadConfig(configFile) != nil {
 				return
 			}
@@ -436,7 +437,7 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 				os.Exit(1)
 			}
 
-			emitEvent := context.Bool(EMIT_POST_MIGRATION_EVENT_FLAG)
+			emitEvent := context.Bool(EmitPostMigrationEventFlag)
 			if !emitEvent {
 				return
 			}
@@ -486,8 +487,8 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 
 				if _, ok := environmentManager.GetEnvironment(s.ID); !ok {
 					env := otto.NewEnvironment("post-migration-env", dbConn, identity, sync)
-					eventTimeout := context.Duration(POST_MIGRATION_EVENT_TIMEOUT_FLAG)
-					env.SetEventTimeLimit(POST_MIGRATION_EVENT, eventTimeout)
+					eventTimeout := context.Duration(PostMigrationEventTimeoutFlag)
+					env.SetEventTimeLimit(PostMigrationEvent, eventTimeout)
 					env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, pluralURL)
 					log.Info("Loading environment for %s schema with URL: %s", s.ID, pluralURL)
 					if err != nil {
@@ -502,7 +503,7 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 				eventContext["sync"] = sync
 				eventContext["db"] = dbConn
 				eventContext["identity_service"] = identity
-				err := env.HandleEvent(POST_MIGRATION_EVENT, eventContext)
+				err := env.HandleEvent(PostMigrationEvent, eventContext)
 				if err != nil {
 					log.Fatalf("Failed to handle event post-migration, err: %s", err)
 				}
@@ -585,10 +586,10 @@ func getCreateInitialMigrationCommand() cli.Command {
 				if s.IsAbstract() {
 					continue
 				}
-				createSql, indices := sqlDB.GenTableDef(s, cascade)
-				sqlString.WriteString(createSql + "\n")
-				for _, indexSql := range indices {
-					sqlString.WriteString(indexSql + "\n")
+				createSQL, indices := sqlDB.GenTableDef(s, cascade)
+				sqlString.WriteString(createSQL + "\n")
+				for _, indexSQL := range indices {
+					sqlString.WriteString(indexSQL + "\n")
 				}
 			}
 			sqlString.WriteString("\n")

--- a/cli/client/arguments.go
+++ b/cli/client/arguments.go
@@ -48,7 +48,7 @@ func (gohanClientCLI *GohanClientCLI) getCustomArgsAsMap(
 			value = actionInput
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing action input %s:", err)
+			return nil, fmt.Errorf("Error parsing action input %s", err)
 		}
 		argsMap[action.ID] = value
 	}

--- a/cli/client/commands.go
+++ b/cli/client/commands.go
@@ -110,7 +110,7 @@ func (gohanClientCLI *GohanClientCLI) getGetCommand(s *schema.Schema) gohanComma
 					buffer.WriteString(childSchema.Title)
 					buffer.WriteString("\n")
 					parentSchemaPropertyID := childSchema.ParentSchemaPropertyID()
-					url := fmt.Sprintf("%s%s?%s=%s", gohanClientCLI.opts.gohanEndpointURL, childSchema.URL, parentSchemaPropertyID, id, gohanClientCLI.getFieldsParam(false))
+					url := fmt.Sprintf("%s%s?%s=%s%s", gohanClientCLI.opts.gohanEndpointURL, childSchema.URL, parentSchemaPropertyID, id, gohanClientCLI.getFieldsParam(false))
 					result, err := gohanClientCLI.request("GET", url, nil)
 					if err != nil {
 						return "", err

--- a/cli/template.go
+++ b/cli/template.go
@@ -109,11 +109,12 @@ func toSwaggerPath(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo
 	return pongo2.AsValue(r.ReplaceAllString(i, "{$1}")), nil
 }
 
-func hasIdParam(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+func hasIDParam(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 	i := in.String()
 	return pongo2.AsValue(strings.Contains(i, ":id")), nil
 }
 
+// SnakeToCamel  changes value from snake case to camel case
 func SnakeToCamel(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 	i := in.String()
 	return pongo2.AsValue(snaker.SnakeToCamel(i)), nil
@@ -143,11 +144,12 @@ func toGoType(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Err
 func init() {
 	pongo2.RegisterFilter("swagger", toSwagger)
 	pongo2.RegisterFilter("swagger_path", toSwaggerPath)
-	pongo2.RegisterFilter("swagger_has_id_param", hasIdParam)
+	pongo2.RegisterFilter("swagger_has_id_param", hasIDParam)
 	pongo2.RegisterFilter("to_go_type", toGoType)
 	pongo2.RegisterFilter("snake_to_camel", SnakeToCamel)
 }
 
+// SchemaWithPolicy ...
 type SchemaWithPolicy struct {
 	Schema   *schema.Schema
 	Policies []string

--- a/db/db.go
+++ b/db/db.go
@@ -47,6 +47,7 @@ type DB interface {
 	Options() options.Options
 }
 
+// IsDeadlock checks if error is deadlock
 func IsDeadlock(err error) bool {
 	knownDatabaseErrorMessages := []string{
 		"Deadlock found when trying to get lock; try restarting transaction", /* MySQL / MariaDB */
@@ -187,6 +188,7 @@ func CopyDBResources(input, output DB, overrideExisting bool) error {
 	return nil
 }
 
+// CreateFromConfig creates db connection from config
 func CreateFromConfig(config *util.Config) (DB, error) {
 	dbType := config.GetString("database/type", "sqlite3")
 	dbConnection := config.GetString("database/connection", "")

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -479,21 +479,21 @@ var _ = Describe("Database operation test", func() {
 		)
 
 		const (
-			DEADLOCK_DB_SCHEMA  = "test_data/test_schema.yaml"
-			DEADLOCK_DB_INITIAL = "test_data/test_initial.yaml"
-			DEADLOCK_DB_NAME    = "test_data/deadlock_db.db"
-			DEADLOCK_DB_TYPE    = "sqlite3"
+			deadlockDbSchema  = "test_data/test_schema.yaml"
+			deadlockDbInitial = "test_data/test_initial.yaml"
+			deadlockDbName    = "test_data/deadlock_db.db"
+			deadlockDbType    = "sqlite3"
 		)
 
 		BeforeEach(func() {
-			os.Remove(DEADLOCK_DB_NAME)
-			Expect(manager.LoadSchemaFromFile(DEADLOCK_DB_SCHEMA)).To(Succeed())
-			Expect(db.InitDBWithSchemas(DEADLOCK_DB_TYPE, DEADLOCK_DB_NAME, false, false, true)).To(Succeed())
-			firstConn, err = db.ConnectDB(DEADLOCK_DB_TYPE, DEADLOCK_DB_NAME, db.DefaultMaxOpenConn, connOpts)
+			os.Remove(deadlockDbName)
+			Expect(manager.LoadSchemaFromFile(deadlockDbSchema)).To(Succeed())
+			Expect(db.InitDBWithSchemas(deadlockDbType, deadlockDbName, false, false, true)).To(Succeed())
+			firstConn, err = db.ConnectDB(deadlockDbType, deadlockDbName, db.DefaultMaxOpenConn, connOpts)
 			Expect(err).ToNot(HaveOccurred())
-			secondConn, err = db.ConnectDB(DEADLOCK_DB_TYPE, DEADLOCK_DB_NAME, db.DefaultMaxOpenConn, connOpts)
+			secondConn, err = db.ConnectDB(deadlockDbType, deadlockDbName, db.DefaultMaxOpenConn, connOpts)
 			Expect(err).ToNot(HaveOccurred())
-			initDB, err := db.ConnectDB("yaml", DEADLOCK_DB_INITIAL, db.DefaultMaxOpenConn, options.Default())
+			initDB, err := db.ConnectDB("yaml", deadlockDbInitial, db.DefaultMaxOpenConn, options.Default())
 			defer initDB.Close()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(db.CopyDBResources(initDB, firstConn, false)).To(Succeed())

--- a/db/file/file.go
+++ b/db/file/file.go
@@ -24,11 +24,11 @@ import (
 
 	"context"
 
+	"github.com/cloudwan/gohan/db/options"
 	"github.com/cloudwan/gohan/db/pagination"
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
-	"github.com/cloudwan/gohan/db/options"
 )
 
 //DB is yaml implementation of DB
@@ -52,7 +52,7 @@ func NewDB(options options.Options) *DB {
 	return &DB{options: options}
 }
 
-//Return DB options
+//Options return DB options
 func (db *DB) Options() options.Options {
 	return db.options
 }
@@ -64,6 +64,7 @@ func (db *DB) Connect(format, conn string, maxOpenConn int) error {
 	return nil
 }
 
+//Close db
 func (db *DB) Close() {
 	// nothing to do
 }
@@ -75,7 +76,7 @@ func (db *DB) Begin() (transaction.Transaction, error) {
 	}, nil
 }
 
-//Begin connection starts new transaction with given transaction options
+//BeginTx connection starts new transaction with given transaction options
 func (db *DB) BeginTx(_ context.Context, _ *transaction.TxOptions) (transaction.Transaction, error) {
 	return &Transaction{
 		db: db,
@@ -290,7 +291,7 @@ func (tx *Transaction) List(s *schema.Schema, filter transaction.Filter, options
 	return
 }
 
-//Lock resources in the db. Not supported in file db
+//LockList resources in the db. Not supported in file db
 func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, options *transaction.ListOptions, pg *pagination.Paginator, policy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
 	return tx.List(s, filter, options, pg)
 }
@@ -307,7 +308,7 @@ func (tx *Transaction) Fetch(s *schema.Schema, filter transaction.Filter) (*sche
 	return list[0], nil
 }
 
-//Fetch & lock a resource. Not supported in file db
+//LockFetch fetches and locks a resource. Not supported in file db
 func (tx *Transaction) LockFetch(s *schema.Schema, filter transaction.Filter, policy schema.LockPolicy) (*schema.Resource, error) {
 	return tx.Fetch(s, filter)
 }

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -29,6 +29,7 @@ import (
 
 var logger = log.NewLogger()
 
+// LoadConfig loads config from config file
 func LoadConfig(configFile string) (err error) {
 	config := util.GetConfig()
 
@@ -57,6 +58,7 @@ func readGooseConfig() (dbType, dbConnection, migrationsPath string, noInit bool
 	return
 }
 
+// Init initialises migration
 func Init() error {
 	logger.Info("migration: init")
 
@@ -118,10 +120,12 @@ func Init() error {
 	return goose.Status(db, migrationsPath)
 }
 
+// Help outputs migration sub command help
 func Help() {
 	fmt.Println("missing subcommand: help, up, up-by-one, up-to, create, create-next, down, down-to, redo, status, version")
 }
 
+// Run executes migration
 func Run(subCmd string, args []string) error {
 	dbType, dbConnection, migrationsPath, _ := readGooseConfig()
 
@@ -152,13 +156,15 @@ func Run(subCmd string, args []string) error {
 
 var modifiedSchemas = map[string]bool{}
 
+// MarkSchemaAsModified marks schema as modified
 func MarkSchemaAsModified(schemaID string) {
 	modifiedSchemas[schemaID] = true
 }
 
+// GetModifiedSchemas gets all modified schemas
 func GetModifiedSchemas() []string {
 	schemas := make([]string, len(modifiedSchemas))
-	for schema, _ := range modifiedSchemas {
+	for schema := range modifiedSchemas {
 		schemas = append(schemas, schema)
 	}
 	return schemas

--- a/db/options/options.go
+++ b/db/options/options.go
@@ -22,19 +22,21 @@ import (
 
 // default transaction retry options
 const (
-	DEFAULT_DEADLOCK_RETRY_TX_INTERVAL = time.Duration(0) * time.Millisecond
-	DEFAULT_DEADLOCK_RETRY_TX_COUNT    = 0
+	DefaultDeadlockRetryTxInterval = time.Duration(0) * time.Millisecond
+	DefaultDeadlockRetryTxCount    = 0
 )
 
+// Options is type for retry transaction options
 type Options struct {
 	RetryTxCount    int
 	RetryTxInterval time.Duration
 }
 
+// Read gets retry transaction options from config
 func Read(config *util.Config) Options {
 	opts := Options{
-		RetryTxCount:    config.GetInt("database/deadlock_retry_tx/count", DEFAULT_DEADLOCK_RETRY_TX_COUNT),
-		RetryTxInterval: time.Duration(config.GetInt("database/deadlock_retry_tx/interval_msec", int(DEFAULT_DEADLOCK_RETRY_TX_INTERVAL))) * time.Millisecond,
+		RetryTxCount:    config.GetInt("database/deadlock_retry_tx/count", DefaultDeadlockRetryTxCount),
+		RetryTxInterval: time.Duration(config.GetInt("database/deadlock_retry_tx/interval_msec", int(DefaultDeadlockRetryTxInterval))) * time.Millisecond,
 	}
 
 	if opts.RetryTxCount < 0 {
@@ -44,9 +46,10 @@ func Read(config *util.Config) Options {
 	return opts
 }
 
+// Default returns default retry transaction options
 func Default() Options {
 	return Options{
-		RetryTxCount:    DEFAULT_DEADLOCK_RETRY_TX_COUNT,
-		RetryTxInterval: DEFAULT_DEADLOCK_RETRY_TX_INTERVAL,
+		RetryTxCount:    DefaultDeadlockRetryTxCount,
+		RetryTxInterval: DefaultDeadlockRetryTxInterval,
 	}
 }

--- a/db/sql/sql_isolation_test.go
+++ b/db/sql/sql_isolation_test.go
@@ -27,10 +27,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/cloudwan/gohan/db/options"
 	"github.com/cloudwan/gohan/db/transaction"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/cloudwan/gohan/db/options"
 )
 
 var _ = Describe("Mysql", func() {

--- a/db/transaction/fuzzy_transaction.go
+++ b/db/transaction/fuzzy_transaction.go
@@ -32,9 +32,8 @@ type FuzzyTransaction struct {
 func (ft *FuzzyTransaction) fuzzIt(fn func() error) error {
 	if rand.Int()&1 == 0 {
 		return fmt.Errorf("database is locked")
-	} else {
-		return fn()
 	}
+	return fn()
 }
 
 // Create creates a new resource
@@ -47,7 +46,7 @@ func (ft *FuzzyTransaction) Update(resource *schema.Resource) error {
 	return ft.fuzzIt(func() error { return ft.Tx.Update(resource) })
 }
 
-// StatueUpdate updates a state
+// StateUpdate updates a state
 func (ft *FuzzyTransaction) StateUpdate(resource *schema.Resource, state *ResourceState) error {
 	return ft.fuzzIt(func() error { return ft.Tx.StateUpdate(resource, state) })
 }

--- a/db/transaction/transaction.go
+++ b/db/transaction/transaction.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// ErrResourceNotFound is error message for missing resource
 var ErrResourceNotFound = errors.New("resource not found")
 
 //Type represents transaction types

--- a/extension/extension.go
+++ b/extension/extension.go
@@ -96,13 +96,13 @@ type Error struct {
 	ExceptionInfo map[string]interface{}
 }
 
-func measureExtensionTime(timeStarted time.Time, event string, schemaId string) {
-	metrics.UpdateTimer(timeStarted, "ext.%s.%s", schemaId, event)
+func measureExtensionTime(timeStarted time.Time, event string, schemaID string) {
+	metrics.UpdateTimer(timeStarted, "ext.%s.%s", schemaID, event)
 }
 
 //HandleEvent handles the event in the given environment
-func HandleEvent(context map[string]interface{}, environment Environment, event string, schemaId string) error {
-	defer measureExtensionTime(time.Now(), event, schemaId)
+func HandleEvent(context map[string]interface{}, environment Environment, event string, schemaID string) error {
+	defer measureExtensionTime(time.Now(), event, schemaID)
 	if err := environment.HandleEvent(event, context); err != nil {
 		return err
 	}

--- a/extension/framework/framework.go
+++ b/extension/framework/framework.go
@@ -115,7 +115,7 @@ func RunTests(testFiles []string, printAllLogs bool, testFilter string, workers 
 	for workers > 0 {
 		wg.Add(1)
 		go worker()
-		workers -= 1
+		workers--
 	}
 	wg.Wait()
 

--- a/extension/framework/runner/environment.go
+++ b/extension/framework/runner/environment.go
@@ -30,12 +30,13 @@ import (
 	"github.com/cloudwan/gohan/sync/noop"
 	"github.com/xyproto/otto"
 
+	// Import otto underscore lib
 	_ "github.com/xyproto/otto/underscore"
 
 	"context"
 
-	gohan_otto "github.com/cloudwan/gohan/extension/otto"
 	"github.com/cloudwan/gohan/db/options"
+	gohan_otto "github.com/cloudwan/gohan/extension/otto"
 )
 
 const (
@@ -167,7 +168,7 @@ func (env *Environment) addTestingAPI() {
 	builtins := map[string]interface{}{
 		"Fail": func(call otto.FunctionCall) otto.Value {
 			if len(call.ArgumentList) == 0 {
-				panic(fmt.Errorf("Fail!"))
+				panic(fmt.Errorf("Fail"))
 			}
 
 			if !call.ArgumentList[0].IsString() {

--- a/extension/gohanscript/lib/gohan.go
+++ b/extension/gohanscript/lib/gohan.go
@@ -20,13 +20,13 @@ import (
 	"strings"
 
 	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/options"
 	"github.com/cloudwan/gohan/db/sql"
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/gohanscript"
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
-	"github.com/cloudwan/gohan/db/options"
 )
 
 func init() {

--- a/extension/gohanscript/lib/lib_test.go
+++ b/extension/gohanscript/lib/lib_test.go
@@ -17,6 +17,7 @@ package lib_test
 
 import (
 	"github.com/cloudwan/gohan/extension/gohanscript"
+	// Import gohan script lib
 	_ "github.com/cloudwan/gohan/extension/gohanscript/autogen"
 	"testing"
 )

--- a/extension/otto/gohan_sync.go
+++ b/extension/otto/gohan_sync.go
@@ -16,10 +16,10 @@
 package otto
 
 import (
+	"fmt"
 	"github.com/cloudwan/gohan/sync"
 	"github.com/xyproto/otto"
 	"time"
-	"fmt"
 )
 
 func convertSyncEvent(event *sync.Event) map[string]interface{} {

--- a/extension/otto/otto.go
+++ b/extension/otto/otto.go
@@ -32,11 +32,11 @@ import (
 	"github.com/xyproto/otto"
 
 	"reflect"
-	//Import otto underscore lib
 	"regexp"
 
 	"strings"
 
+	//Import otto underscore lib
 	_ "github.com/xyproto/otto/underscore"
 )
 
@@ -53,9 +53,8 @@ func RequireModule(name string) (interface{}, error) {
 	v, ok := modules[name]
 	if ok {
 		return v, nil
-	} else {
-		return nil, fmt.Errorf("Module %s not found in Otto", name)
 	}
+	return nil, fmt.Errorf("Module %s not found in Otto", name)
 }
 
 //Environment javascript based environment for gohan extension
@@ -349,6 +348,7 @@ func (env *Environment) GetOrCreateTransaction(value otto.Value) (transaction.Tr
 	return tx, true, nil
 }
 
+// ClearEnvironment closes sync and db in env
 func (env *Environment) ClearEnvironment() {
 	env.Sync.Close()
 	env.DataStore.Close()

--- a/extension/otto/otto_suite_test.go
+++ b/extension/otto/otto_suite_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/util"
 
+	"github.com/cloudwan/gohan/db/options"
 	"github.com/cloudwan/gohan/sync/etcdv3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/cloudwan/gohan/db/options"
 )
 
 const (

--- a/job/queue.go
+++ b/job/queue.go
@@ -28,7 +28,7 @@ type Job struct {
 
 //Run executes one Job
 func (job *Job) Run() {
-	defer l.LogPanic(log)
+	defer l.Panic(log)
 	job.task()
 }
 
@@ -56,7 +56,7 @@ func NewWorker(queue *Queue) *Worker {
 //Start consuming task
 func (worker *Worker) Start() {
 	go func() {
-		l.LogPanic(log)
+		l.Panic(log)
 		for {
 			select {
 			case job := <-worker.queue.queue:

--- a/log/log.go
+++ b/log/log.go
@@ -83,9 +83,9 @@ func getModuleName() string {
 	// 0 - this function
 	// 1 - NewLogger
 	// 2 - calling module
-	const SKIP_STACK_FRAMES = 2
+	const SkipStackFrames = 2
 
-	pc, _, _, ok := runtime.Caller(SKIP_STACK_FRAMES)
+	pc, _, _, ok := runtime.Caller(SkipStackFrames)
 	if !ok {
 		return defaultLoggerName
 	}

--- a/log/util.go
+++ b/log/util.go
@@ -5,16 +5,16 @@ import (
 	"runtime/debug"
 )
 
-//LogPanic logs panic and prevent crash
-func LogPanic(log Logger) {
+//Panic logs panic and prevent crash
+func Panic(log Logger) {
 	err := recover()
 	if err != nil {
 		log.Error(fmt.Sprintf("Panic %s: %s", err, debug.Stack()))
 	}
 }
 
-//LogFatalPanic logs panic and crashes Gohan process
-func LogFatalPanic(log Logger) {
+//FatalPanic logs panic and crashes Gohan process
+func FatalPanic(log Logger) {
 	err := recover()
 	if err != nil {
 		log.Fatalf("Panic %s: %s", err, debug.Stack())

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -61,12 +61,14 @@ func getGraphiteConfig(config *util.Config) (graphiteConfigs []graphite.Config, 
 	return graphiteConfigs, nil
 }
 
+// SetupMetrics setups metrics from config
 func SetupMetrics(config *util.Config) (err error) {
 	monitoringEnabled = config.GetBool("metrics/enabled", false)
 	graphiteConfigs, err = getGraphiteConfig(config)
 	return
 }
 
+// StartMetricsProcess starts to send runtime metrics to graphite
 func StartMetricsProcess() {
 	if monitoringEnabled && len(graphiteConfigs) > 0 {
 		log.Debug("Starting sending runtime metrics to graphite, config %+v", graphiteConfigs)
@@ -79,6 +81,7 @@ func StartMetricsProcess() {
 	}
 }
 
+// UpdateTimer updates metrics timer
 func UpdateTimer(since time.Time, format string, args ...interface{}) {
 	if monitoringEnabled {
 		m := metrics.GetOrRegisterTimer(fmt.Sprintf(format, args...), metrics.DefaultRegistry)

--- a/schema/index.go
+++ b/schema/index.go
@@ -20,8 +20,11 @@ import (
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// IndexType type of index
 type IndexType string
 
+// Index types
+// Unique, FullText, Spatial, None
 const (
 	Unique   IndexType = "UNIQUE"
 	FullText           = "FULLTEXT"
@@ -29,14 +32,14 @@ const (
 	None               = ""
 )
 
-//Property is a definition of each Property
+// Index is a definition of each Index
 type Index struct {
 	Name    string
 	Columns []string
 	Type    IndexType
 }
 
-//NewProperty is a constructor for Property type
+//NewIndex is a constructor for Index type
 func NewIndex(name string, columns []string, indexType IndexType) Index {
 	return Index{
 		Name:    name,
@@ -55,7 +58,7 @@ func mapIndexType(rawIndexType string) (IndexType, error) {
 	}
 }
 
-//NewPropertyFromObj make Index  from obj
+//NewIndexFromObj make Index  from obj
 func NewIndexFromObj(name string, rawTypeData interface{}) (*Index, error) {
 	typeData := rawTypeData.(map[string]interface{})
 	rawIndexType, ok := typeData["type"]

--- a/schema/manager.go
+++ b/schema/manager.go
@@ -305,8 +305,8 @@ func (manager *Manager) ValidateSchema(schemaPath, filePath string) error {
 
 //OrderedLoadSchemasFromFiles calls LoadSchemaFromFile for each file in right order - first abstract then parent and rest on the end
 func (manager *Manager) OrderedLoadSchemasFromFiles(filePaths []string) error {
-	MAX_DEPTH := 8 // maximum number of nested schemas
-	for i := MAX_DEPTH; i > 0 && len(filePaths) > 0; i-- {
+	MaxDepth := 8 // maximum number of nested schemas
+	for i := MaxDepth; i > 0 && len(filePaths) > 0; i-- {
 		rest := make([]string, 0)
 		for _, filePath := range filePaths {
 			if filePath == "" {

--- a/schema/policy.go
+++ b/schema/policy.go
@@ -43,6 +43,7 @@ const (
 	onlyOneOfTenantIDTenantNameError = "Only one of [tenant_id, tenant_name] should be specified"
 )
 
+// AllActions are all possible actions
 var AllActions = []string{ActionCreate, ActionRead, ActionUpdate, ActionDelete}
 
 func newTenant(tenantID, tenantName string) Tenant {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -56,8 +56,10 @@ const (
 	abstract string = "abstract"
 )
 
+// LockPolicy is type lock policy
 type LockPolicy int
 
+// LockRelatedResources is type of LockPolicy
 const (
 	LockRelatedResources LockPolicy = iota
 	SkipRelatedResources
@@ -165,6 +167,7 @@ func newSchemaFromObj(rawTypeData interface{}, metaschema *Schema) (*Schema, err
 	return schema, nil
 }
 
+// PropertyOrder is type of property order
 type PropertyOrder struct {
 	properties      []Property
 	propertiesOrder []string
@@ -195,22 +198,21 @@ func (p PropertyOrder) Less(i, j int) bool {
 		return false
 	} else if iIdx != -1 && jIdx != -1 {
 		return iIdx < jIdx
+	}
+	if lhv.ID == "id" {
+		return true
+	}
+	if lhv.Indexed && !rhv.Indexed {
+		return true
+	} else if !lhv.Indexed && rhv.Indexed {
+		return false
 	} else {
-		if lhv.ID == "id" {
+		if lhv.Relation != "" && rhv.Relation == "" {
 			return true
-		}
-		if lhv.Indexed && !rhv.Indexed {
-			return true
-		} else if !lhv.Indexed && rhv.Indexed {
+		} else if lhv.Relation == "" && rhv.Relation != "" {
 			return false
 		} else {
-			if lhv.Relation != "" && rhv.Relation == "" {
-				return true
-			} else if lhv.Relation == "" && rhv.Relation != "" {
-				return false
-			} else {
-				return lhv.ID < rhv.ID
-			}
+			return lhv.ID < rhv.ID
 		}
 	}
 }
@@ -627,6 +629,7 @@ func (schema *Schema) JSON() map[string]interface{} {
 	}
 }
 
+// GetLockingPolicy gets locking policy for given schema and event
 func (schema *Schema) GetLockingPolicy(event string) LockPolicy {
 	if schema.Metadata["locking_policy"] == nil {
 		return NoLocking

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -84,11 +84,11 @@ var _ = Describe("Schema", func() {
 		It("Relations after propertiesOrder", func() {
 			s, ok := manager.Schema("school")
 			Expect(ok).To(BeTrue())
-			cityIdIdx := index(s.Properties, "city_id")
+			cityIDIdx := index(s.Properties, "city_id")
 			patronIdx := index(s.Properties, "patron")
-			Expect(cityIdIdx).ToNot(Equal(-1))
+			Expect(cityIDIdx).ToNot(Equal(-1))
 			Expect(patronIdx).ToNot(Equal(-1))
-			Expect(cityIdIdx).Should(BeNumerically("<", patronIdx))
+			Expect(cityIDIdx).Should(BeNumerically("<", patronIdx))
 		})
 
 		It("Alphabetical order", func() {

--- a/schema/timelimits.go
+++ b/schema/timelimits.go
@@ -28,6 +28,7 @@ type PathEventTimeLimit struct {
 	TimeDuration time.Duration
 }
 
+// NewPathEventTimeLimit is a constructor for PathEventTimeLimit
 func NewPathEventTimeLimit(pathRegex, eventRegex string, timeDuration time.Duration) *PathEventTimeLimit {
 	return &PathEventTimeLimit{
 		PathRegex:    regexp.MustCompile(pathRegex),
@@ -48,6 +49,7 @@ type EventTimeLimit struct {
 	TimeDuration time.Duration
 }
 
+// NewEventTimeLimit is a constructor for EventTimeLimit
 func NewEventTimeLimit(eventRegex *regexp.Regexp, timeLimit time.Duration) *EventTimeLimit {
 	return &EventTimeLimit{
 		EventRegex:   eventRegex,

--- a/server/amqp.go
+++ b/server/amqp.go
@@ -63,7 +63,7 @@ func listenAMQP(server *Server) {
 
 	for _, queue := range queues {
 		go func(queue string) {
-			defer l.LogFatalPanic(log)
+			defer l.FatalPanic(log)
 			for server.running {
 				conn, err := amqp.Dial(connection)
 				if err != nil {

--- a/server/cron.go
+++ b/server/cron.go
@@ -35,7 +35,7 @@ func startCRONProcess(server *Server) {
 	}
 	if server.sync == nil {
 		log.Fatalf(fmt.Sprintf("Could not start CRON process because of sync backend misconfiguration."))
-		l.LogFatalPanic(log)
+		l.FatalPanic(log)
 	}
 	log.Info("Started CRON process")
 	c := cron.New()

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -114,6 +114,7 @@ type IdentityService interface {
 	GetClient() *gophercloud.ServiceClient
 }
 
+// CreateIdentityServiceFromConfig creates keystone identity from config
 func CreateIdentityServiceFromConfig(config *util.Config) (IdentityService, error) {
 	//TODO(marcin) remove this
 	if config.GetBool("keystone/use_keystone", false) {
@@ -123,20 +124,19 @@ func CreateIdentityServiceFromConfig(config *util.Config) (IdentityService, erro
 			log.Info("Debug Mode with Fake Keystone Server")
 			return &FakeIdentity{}, nil
 
-		} else {
-			log.Info("Keystone backend server configured")
-			keystoneIdentity, err := cloud.NewKeystoneIdentity(
-				config.GetString("keystone/auth_url", "http://localhost:35357/v3"),
-				config.GetString("keystone/user_name", "admin"),
-				config.GetString("keystone/password", "password"),
-				config.GetString("keystone/domain_name", "Default"),
-				config.GetString("keystone/tenant_name", "admin"),
-				config.GetString("keystone/version", ""))
-			if err != nil {
-				log.Fatal("Failed to create keystone identity service, err: %s", err)
-			}
-			return keystoneIdentity, nil
 		}
+		log.Info("Keystone backend server configured")
+		keystoneIdentity, err := cloud.NewKeystoneIdentity(
+			config.GetString("keystone/auth_url", "http://localhost:35357/v3"),
+			config.GetString("keystone/user_name", "admin"),
+			config.GetString("keystone/password", "password"),
+			config.GetString("keystone/domain_name", "Default"),
+			config.GetString("keystone/tenant_name", "admin"),
+			config.GetString("keystone/version", ""))
+		if err != nil {
+			log.Fatal(fmt.Sprintf("Failed to create keystone identity service, err: %s", err))
+		}
+		return keystoneIdentity, nil
 	}
 	return nil, fmt.Errorf("No identity service defined in config")
 }
@@ -146,10 +146,12 @@ type NobodyResourceService interface {
 	VerifyResourcePath(string) bool
 }
 
+// DefaultNobodyResourceService contains a definition of default nobody resources
 type DefaultNobodyResourceService struct {
 	resourcePathRegexes []*regexp.Regexp
 }
 
+// VerifyResourcePath verifies resource path
 func (nrs *DefaultNobodyResourceService) VerifyResourcePath(resourcePath string) bool {
 	for _, regex := range nrs.resourcePathRegexes {
 		if regex.MatchString(resourcePath) {
@@ -159,6 +161,7 @@ func (nrs *DefaultNobodyResourceService) VerifyResourcePath(resourcePath string)
 	return false
 }
 
+// NewNobodyResourceService is a constructor for NobodyResourceService
 func NewNobodyResourceService(nobodyResourcePathRegexes []*regexp.Regexp) NobodyResourceService {
 	return &DefaultNobodyResourceService{resourcePathRegexes: nobodyResourcePathRegexes}
 }

--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -74,8 +74,8 @@ type ExtensionError struct {
 	ExceptionInfo map[string]interface{}
 }
 
-func measureRequestTime(timeStarted time.Time, requestType string, schemaId string) {
-	metrics.UpdateTimer(timeStarted, "req.%s.%s", schemaId, requestType)
+func measureRequestTime(timeStarted time.Time, requestType string, schemaID string) {
+	metrics.UpdateTimer(timeStarted, "req.%s.%s", schemaID, requestType)
 }
 
 //resourceTransactionWithContext executes function in the db transaction and set it to the context
@@ -94,7 +94,7 @@ func resourceTransactionWithContext(ctx middleware.Context, dataStore db.DB, lev
 	}
 
 	return db.WithinTx(dataStore, context.Background(), &transaction.TxOptions{IsolationLevel: level}, func(tx transaction.Transaction) error {
-		for k, _ := range ctx {
+		for k := range ctx {
 			delete(ctx, k)
 		}
 
@@ -756,7 +756,7 @@ func DeleteResource(context middleware.Context,
 	var resource *schema.Resource
 	var fetchErr error
 
-	if errPreTx := db.Within(dataStore, func (preTransaction transaction.Transaction) error {
+	if errPreTx := db.Within(dataStore, func(preTransaction transaction.Transaction) error {
 		tenantIDs := policy.GetTenantIDFilter(schema.ActionDelete, auth.TenantID())
 		filter := transaction.IDFilter(resourceID)
 		if tenantIDs != nil {

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/otto"
 	"github.com/cloudwan/gohan/schema"
@@ -29,8 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/twinj/uuid"
-	"github.com/cloudwan/gohan/db"
-	"github.com/cloudwan/gohan/db/transaction"
 )
 
 var _ = Describe("Resource manager", func() {
@@ -103,7 +103,7 @@ var _ = Describe("Resource manager", func() {
 	})
 
 	AfterEach(func() {
-		Expect(db.Within(testDB, func (tx transaction.Transaction) error {
+		Expect(db.Within(testDB, func(tx transaction.Transaction) error {
 
 			environmentManager.UnRegisterEnvironment(schemaID)
 			defer tx.Close()

--- a/server/resync.go
+++ b/server/resync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudwan/gohan/util"
 )
 
+// Resync performs resync
 func Resync(dbConn db.DB, sync sync.Sync) (err error) {
 
 	syncDbConn := &DbSyncWrapper{DB: dbConn}

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,8 @@ import (
 	"github.com/cloudwan/gohan/db"
 	"github.com/cloudwan/gohan/db/migration"
 
+	"github.com/cloudwan/gohan/db/options"
+	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/job"
 	l "github.com/cloudwan/gohan/log"
@@ -47,8 +49,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"github.com/cloudwan/gohan/db/transaction"
-	"github.com/cloudwan/gohan/db/options"
 )
 
 type tlsConfig struct {

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/cloudwan/gohan/db"
-	"github.com/cloudwan/gohan/schema"
 	"github.com/cloudwan/gohan/db/options"
+	"github.com/cloudwan/gohan/schema"
 )
 
 const (

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,7 +59,7 @@ var (
 var _ = Describe("Server package test", func() {
 
 	AfterEach(func() {
-		Expect(db.Within(testDB, func (tx transaction.Transaction) error {
+		Expect(db.Within(testDB, func(tx transaction.Transaction) error {
 			for _, schema := range schema.GetManager().Schemas() {
 				if whitelist[schema.ID] {
 					continue

--- a/server/snmp.go
+++ b/server/snmp.go
@@ -53,7 +53,7 @@ func startSNMPProcess(server *Server) {
 
 	buf := make([]byte, 1024)
 	go func() {
-		defer l.LogFatalPanic(log)
+		defer l.FatalPanic(log)
 		defer conn.Close()
 		for server.running {
 			rlen, remote, err := conn.ReadFromUDP(buf)

--- a/server/state_watcher.go
+++ b/server/state_watcher.go
@@ -65,6 +65,7 @@ func NewStateWatcher(sync gohan_sync.Sync, db db.DB, identity middleware.Identit
 	}
 }
 
+// NewStateWatcherFromServer is a constructor for StateWatcher
 func NewStateWatcherFromServer(server *Server) *StateWatcher {
 	return NewStateWatcher(server.sync, server.db, server.keystoneIdentity)
 }
@@ -240,7 +241,6 @@ func (watcher *StateWatcher) MonitoringUpdate(event *gohan_sync.Event) error {
 	resourceID := curSchema.GetResourceIDFromPath(schemaPath)
 	log.Info("Started MonitoringUpdate for %s %s %v", event.Action, event.Key, event.Data)
 
-
 	return db.WithinTx(watcher.db, context.Background(), &transaction.TxOptions{IsolationLevel: transaction.GetIsolationLevel(curSchema, MonitoringUpdateEventName)},
 		func(tx transaction.Transaction) error {
 			curResource, err := tx.Fetch(curSchema, transaction.IDFilter(resourceID))
@@ -301,7 +301,6 @@ func (watcher *StateWatcher) MonitoringUpdate(event *gohan_sync.Event) error {
 		})
 }
 
-func (watcher *StateWatcher) measureStateUpdateTime(timeStarted time.Time, event string, schemaId string) {
-	metrics.UpdateTimer(timeStarted, "state.%s.%s", schemaId, event)
+func (watcher *StateWatcher) measureStateUpdateTime(timeStarted time.Time, event string, schemaID string) {
+	metrics.UpdateTimer(timeStarted, "state.%s.%s", schemaID, event)
 }
-

--- a/server/sync_watcher_test.go
+++ b/server/sync_watcher_test.go
@@ -22,10 +22,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/schema"
 	srv "github.com/cloudwan/gohan/server"
-	"github.com/cloudwan/gohan/db/transaction"
-	"github.com/cloudwan/gohan/db"
 )
 
 const (
@@ -42,7 +42,7 @@ var _ = Describe("Sync watcher test", func() {
 	})
 
 	AfterEach(func() {
-		Expect(db.Within(testDB, func (tx transaction.Transaction) error {
+		Expect(db.Within(testDB, func(tx transaction.Transaction) error {
 			for _, schema := range schema.GetManager().Schemas() {
 				if whitelist[schema.ID] {
 					continue

--- a/server/sync_writer.go
+++ b/server/sync_writer.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/cloudwan/gohan/db"
 	"github.com/cloudwan/gohan/db/pagination"
+	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/schema"
 	gohan_sync "github.com/cloudwan/gohan/sync"
-	"github.com/cloudwan/gohan/db/transaction"
 )
 
 const (
@@ -123,14 +123,14 @@ func (writer *SyncWriter) Sync() (synced int, err error) {
 		if err != nil {
 			return
 		}
-		synced += 1
+		synced++
 	}
 	return
 }
 
 func (writer *SyncWriter) listEvents() ([]*schema.Resource, error) {
 	var resourceList []*schema.Resource
-	if dbErr := db.Within(writer.db, func (tx transaction.Transaction) error {
+	if dbErr := db.Within(writer.db, func(tx transaction.Transaction) error {
 		schemaManager := schema.GetManager()
 		eventSchema, _ := schemaManager.Schema("event")
 		paginator, _ := pagination.NewPaginator(eventSchema, "id", pagination.ASC, eventPollingLimit, 0)
@@ -147,7 +147,7 @@ func (writer *SyncWriter) listEvents() ([]*schema.Resource, error) {
 func (writer *SyncWriter) syncEvent(resource *schema.Resource) error {
 	schemaManager := schema.GetManager()
 	eventSchema, _ := schemaManager.Schema("event")
-	return db.Within(writer.db, func (tx transaction.Transaction) error {
+	return db.Within(writer.db, func(tx transaction.Transaction) error {
 		var err error
 		eventType := resource.Get("type").(string)
 		resourcePath := resource.Get("path").(string)

--- a/server/transaction_commit_informer.go
+++ b/server/transaction_commit_informer.go
@@ -50,8 +50,7 @@ func (sw *DbSyncWrapper) Begin() (transaction.Transaction, error) {
 	return syncTransactionWrap(tx), nil
 }
 
-// Begin wraps transaction object with sync
-
+// BeginTx wraps transaction object with sync
 func (sw *DbSyncWrapper) BeginTx(ctx context.Context, options *transaction.TxOptions) (transaction.Transaction, error) {
 	tx, err := sw.DB.BeginTx(ctx, options)
 	if err != nil {

--- a/sync/etcd/etcd.go
+++ b/sync/etcd/etcd.go
@@ -265,6 +265,7 @@ func (s *Sync) WatchContext(ctx context.Context, path string, revision int64) (<
 	return responseChan, nil
 }
 
+// Close closes sync
 func (s *Sync) Close() {
 	// nothing to do
 }

--- a/sync/etcdv3/etcd.go
+++ b/sync/etcdv3/etcd.go
@@ -85,9 +85,8 @@ func (s *Sync) Update(key, jsonString string) error {
 	if jsonString == "" {
 		// do nothing, because clientv3 doesn't have directories
 		return nil
-	} else {
-		_, err = s.etcdClient.Put(s.withTimeout(), key, jsonString)
 	}
+	_, err = s.etcdClient.Put(s.withTimeout(), key, jsonString)
 	if err != nil {
 		log.Error(fmt.Sprintf("failed to sync with backend %s", err))
 		return err
@@ -350,6 +349,7 @@ func (s *Sync) WatchContext(ctx context.Context, path string, revision int64) (<
 	return responseChan, nil
 }
 
+// Close closes etcd client
 func (s *Sync) Close() {
 	s.etcdClient.Close()
 }

--- a/sync/noop/noop.go
+++ b/sync/noop/noop.go
@@ -45,6 +45,7 @@ func (sync *Sync) Delete(path string, prefix bool) error {
 	return nil
 }
 
+// Fetch sync
 func (sync *Sync) Fetch(path string) (*sync.Node, error) {
 	return nil, nil
 }
@@ -74,6 +75,7 @@ func (sync *Sync) WatchContext(ctx context.Context, path string, revision int64)
 	return nil, nil
 }
 
+// Close sync
 func (sync *Sync) Close() {
 
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -21,6 +21,7 @@ import (
 	l "github.com/cloudwan/gohan/log"
 )
 
+// RevisionCurrent is current sync revision
 const RevisionCurrent = -1
 
 var log = l.NewLogger()

--- a/sync/util/etcd.go
+++ b/sync/util/etcd.go
@@ -13,6 +13,7 @@ import (
 
 var log = l.NewLogger()
 
+// CreateFromConfig creates etcd sync from config
 func CreateFromConfig(config *util.Config) (s sync.Sync, err error) {
 	syncType := config.GetString("sync", "etcd")
 	switch syncType {

--- a/util/util.go
+++ b/util/util.go
@@ -345,7 +345,7 @@ func MaybeInt(value interface{}) int {
 	return res
 }
 
-//Find return index of elem in slice
+//Index return index of elem in slice
 func Index(slice []string, elem string) int {
 	for i, value := range slice {
 		if value == elem {


### PR DESCRIPTION
cleared go lint/vet warning that didn't require to change logic

Go vet detected some errors fixing which would require to change logic, here is a list of them:
server/state_watcher.go:100 : the watchCancel function is not used on all paths (possible context leak)
server/state_watcher.go:103: this return statement may be reached without using the watchCancel var defined on line 100
server/sync_watcher.go:103: the watchCancel function is not used on all paths (possible context leak)
server/sync_watcher.go:106: this return statement may be reached without using the watchCancel var defined on line 103
server/sync_watcher.go:200: the previousCancel function is not used on all paths (possible context leak)
server/sync_watcher.go:212: this return statement may be reached without using the previousCancel var defined on line 200
server/sync_watcher.go:262: the watchCancel function is not used on all paths (possible context leak)
server/sync_watcher.go:266: this return statement may be reached without using the watchCancel var defined on line 262
util/util.go:181: using resp before checking for errors
sync/etcdv3/etcd.go:50: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak