### PR TITLE
[ESI-13437] Global store must be synchronized

### DIFF
--- a/extension/otto/global_store.go
+++ b/extension/otto/global_store.go
@@ -15,9 +15,12 @@
 
 package otto
 
+import "sync"
+
 // GlobalStore for values living longer that a single extension environment
 type GlobalStore struct {
 	objects map[string]map[string]interface{}
+	mtx     sync.Mutex
 }
 
 // NewGlobalStore ...
@@ -30,6 +33,9 @@ func NewGlobalStore() *GlobalStore {
 // Get a value registered for name,
 // or, if there is none, register an empty object.
 func (store *GlobalStore) Get(name string) map[string]interface{} {
+	store.mtx.Lock()
+	defer store.mtx.Unlock()
+
 	if result, ok := store.objects[name]; ok {
 		return result
 	}


### PR DESCRIPTION
Lack of sychronization of global store caused panics (concurrent map writes)
when parallel JS tests were running. This change adds a missing mutex.