### PR TITLE
ESI-11996 Protect against migrations race optional

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,7 +49,10 @@ import (
 
 var log = l.NewLogger()
 
-const defaultConfigFile = "gohan.yaml"
+const (
+	defaultConfigFile  = "gohan.yaml"
+	syncMigrationsPath = "/gohan/cluster/migrations"
+)
 
 //Run execute main command
 func Run(name, usage, version string) {
@@ -394,6 +397,33 @@ documentation for detail information about writing tests.`,
 	}
 }
 
+func migrationSubcommandWithLock(action func(*cli.Context)) func(*cli.Context) {
+	return func(context *cli.Context) {
+		configFile := context.String("config-file")
+		if migration.LoadConfig(configFile) != nil {
+			return
+		}
+
+		config := util.GetConfig()
+		sync, err := sync_util.CreateFromConfig(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if sync == nil {
+			log.Fatal("sync is nil")
+		}
+
+		_, err = sync.Lock(syncMigrationsPath, true)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer sync.Unlock(syncMigrationsPath)
+
+		action(context)
+	}
+}
+
 func getMigrateSubcommand(subcmd, usage string) cli.Command {
 	return cli.Command{
 		Name:  subcmd,
@@ -401,16 +431,11 @@ func getMigrateSubcommand(subcmd, usage string) cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: "config-file", Value: defaultConfigFile, Usage: "Server config File"},
 		},
-		Action: func(context *cli.Context) {
-			configFile := context.String("config-file")
-			if migration.LoadConfig(configFile) != nil {
-				return
-			}
-
+		Action: migrationSubcommandWithLock(func(context *cli.Context) {
 			if migration.Run(subcmd, context.Args()) != nil {
 				os.Exit(1)
 			}
-		},
+		}),
 	}
 }
 
@@ -431,11 +456,7 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 			cli.DurationFlag{Name: PostMigrationEventTimeoutFlag, Value: time.Second * 30, Usage: "Maximum duration of post-migration event"},
 			cli.BoolFlag{Name: SyncEtcdEventFlag, Usage: "Enable if ETCD events should be synchronized after migration"},
 		},
-		Action: func(context *cli.Context) {
-			configFile := context.String(ConfigFileFlag)
-			if migration.LoadConfig(configFile) != nil {
-				return
-			}
+		Action: migrationSubcommandWithLock(func(context *cli.Context) {
 			config := util.GetConfig()
 
 			if migration.Run(subcmd, context.Args()) != nil {
@@ -513,7 +534,6 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 					log.Fatalf("Failed to handle event post-migration, err: %s", err)
 				}
 			}
-
 			etcdEvent := context.Bool(SyncEtcdEventFlag)
 			if !etcdEvent {
 				return
@@ -524,7 +544,7 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 			if err != nil {
 				log.Fatalf("Failed to synchronize post-migration events, err: %s", err)
 			}
-		},
+		}),
 	}
 
 }

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2017 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"github.com/cloudwan/gohan/sync/etcdv3"
+	"github.com/codegangsta/cli"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sync"
+	"time"
+)
+
+func getContextWithConfig(configFile string) *cli.Context {
+	configFlag := cli.StringFlag{Name: "config-file", Value: configFile}
+	set := flag.NewFlagSet("", flag.ContinueOnError)
+	configFlag.Apply(set)
+	return cli.NewContext(nil, set, &cli.Context{})
+}
+
+var _ = Describe("CLI", func() {
+	Describe("Post migration subcommand wrapper tests", func() {
+		It("Should lock - migrationsSubCommand wrapper", func() {
+			const (
+				configPath = "../tests/test_etcd.yaml"
+				etcdServer = "http://127.0.0.1:2379"
+			)
+
+			waitForLock := sync.WaitGroup{}
+			waitForFail := sync.WaitGroup{}
+
+			lock := func(context *cli.Context) {
+				waitForLock.Done()
+				waitForFail.Wait()
+			}
+
+			etcdSync, err := etcdv3.NewSync([]string{etcdServer}, time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			wrapped := migrationSubcommandWithLock(lock)
+			context := getContextWithConfig(configPath)
+			Expect(context.String("config-file")).To(Equal(configPath))
+
+			waitForFail.Add(1)
+			waitForLock.Add(1)
+			go wrapped(context)
+			waitForLock.Wait()
+			_, err = etcdSync.Lock(syncMigrationsPath, false)
+			waitForFail.Done()
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("failed to lock path %s", syncMigrationsPath)))
+		})
+	})
+})

--- a/sync/util/etcd.go
+++ b/sync/util/etcd.go
@@ -14,23 +14,24 @@ import (
 var log = l.NewLogger()
 
 // CreateFromConfig creates etcd sync from config
-func CreateFromConfig(config *util.Config) (etcdSync sync.Sync, err error) {
+func CreateFromConfig(config *util.Config) (s sync.Sync, err error) {
 	syncType := config.GetString("sync", "etcd")
-	etcdServers := config.GetStringList("etcd", nil)
-	if etcdServers == nil {
-		err = fmt.Errorf("no etcd found in config file")
-		return
-	}
 	switch syncType {
 	case "etcd":
-		log.Info("etcd servers: %s", etcdServers)
-		etcdSync = etcd.NewSync(etcdServers)
+		etcdServers := config.GetStringList("etcd", nil)
+		if etcdServers != nil {
+			log.Info("etcd servers: %s", etcdServers)
+			s = etcd.NewSync(etcdServers)
+		}
 	case "etcdv3":
-		log.Info("etcd servers: %s", etcdServers)
-		etcdSync, err = etcdv3.NewSync(etcdServers, time.Second)
-		if err != nil {
-			err = fmt.Errorf("failed to connect to etcd servers: %s", err)
-			return
+		etcdServers := config.GetStringList("etcd", nil)
+		if etcdServers != nil {
+			log.Info("etcd servers: %s", etcdServers)
+			s, err = etcdv3.NewSync(etcdServers, time.Second)
+			if err != nil {
+				err = fmt.Errorf("failed to connect to etcd servers: %s", err)
+				return
+			}
 		}
 	default:
 		err = fmt.Errorf("invalid sync type: %s", syncType)

--- a/sync/util/etcd.go
+++ b/sync/util/etcd.go
@@ -14,24 +14,23 @@ import (
 var log = l.NewLogger()
 
 // CreateFromConfig creates etcd sync from config
-func CreateFromConfig(config *util.Config) (s sync.Sync, err error) {
+func CreateFromConfig(config *util.Config) (etcdSync sync.Sync, err error) {
 	syncType := config.GetString("sync", "etcd")
+	etcdServers := config.GetStringList("etcd", nil)
+	if etcdServers == nil {
+		err = fmt.Errorf("no etcd found in config file")
+		return
+	}
 	switch syncType {
 	case "etcd":
-		etcdServers := config.GetStringList("etcd", nil)
-		if etcdServers != nil {
-			log.Info("etcd servers: %s", etcdServers)
-			s = etcd.NewSync(etcdServers)
-		}
+		log.Info("etcd servers: %s", etcdServers)
+		etcdSync = etcd.NewSync(etcdServers)
 	case "etcdv3":
-		etcdServers := config.GetStringList("etcd", nil)
-		if etcdServers != nil {
-			log.Info("etcd servers: %s", etcdServers)
-			s, err = etcdv3.NewSync(etcdServers, time.Second)
-			if err != nil {
-				err = fmt.Errorf("failed to connect to etcd servers: %s", err)
-				return
-			}
+		log.Info("etcd servers: %s", etcdServers)
+		etcdSync, err = etcdv3.NewSync(etcdServers, time.Second)
+		if err != nil {
+			err = fmt.Errorf("failed to connect to etcd servers: %s", err)
+			return
 		}
 	default:
 		err = fmt.Errorf("invalid sync type: %s", syncType)

--- a/tests/test_etcd.yaml
+++ b/tests/test_etcd.yaml
@@ -1,0 +1,4 @@
+# list of etcd backend servers
+sync: etcdv3
+etcd:
+    - "http://127.0.0.1:2379"


### PR DESCRIPTION
#488 
#508 

Now usage of etcd during migrations is optional and requires a flag.