### PR TITLE
ESI-13857 cleared golint and go vet errors

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -331,6 +331,10 @@ func getResyncCommand() cli.Command {
 			}
 
 			dbConn, err := db.CreateFromConfig(config)
+			if err != nil {
+				log.Fatalf("Failed to create db conn, err: %s", err)
+			}
+
 			sync, err := sync_util.CreateFromConfig(config)
 			if err != nil {
 				log.Fatalf("Failed to create sync, err: %s", err)
@@ -424,7 +428,7 @@ func getMigrateSubcommandWithPostMigrateEvent(subcmd, usage string) cli.Command 
 		Usage: usage,
 		Flags: []cli.Flag{
 			cli.StringFlag{Name: ConfigFileFlag, Value: defaultConfigFile, Usage: "Server config File"},
-			cli.BoolFlag{Name: EmitPostMigrationEventFlag, Usage: "Enable if post-migration event should be emited to modified schema extensions"},
+			cli.BoolFlag{Name: EmitPostMigrationEventFlag, Usage: "Enable if post-migration event should be emitted to modified schema extensions"},
 			cli.DurationFlag{Name: PostMigrationEventTimeoutFlag, Value: time.Second * 30, Usage: "Maximum duration of post-migration event"},
 			cli.BoolFlag{Name: SyncEtcdEventFlag, Usage: "Enable if ETCD events should be synchronized after migration"},
 		},

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -111,7 +111,10 @@ type GohanClientCLI struct {
 }
 
 func setUpLogging(level l.Level) {
-	l.SetUpBasicLogging(logOutput, l.CliFormat, l.ModuleLevel{"gohan.cli.client", level})
+	l.SetUpBasicLogging(logOutput, l.CliFormat, l.ModuleLevel{
+		Module: "gohan.cli.client",
+		Level:  level,
+	})
 }
 
 func isCustomCommand(command string) bool {

--- a/cli/template_test.go
+++ b/cli/template_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Templates", func() {
 			})
 		})
 
-		Context("With schema containg 2 resources", func() {
+		Context("With schema containing 2 resources", func() {
 			It("should recognize correctly all of them", func() {
 
 				resources := getAllResourcesFromSchemas(schemaWithPolicy)

--- a/db/db.go
+++ b/db/db.go
@@ -114,7 +114,7 @@ func Within(db DB, fn func(transaction.Transaction) error) error {
 }
 
 // WithinTx executes a scoped transaction with options on a database
-func WithinTx(db DB, ctx context.Context, options *transaction.TxOptions, fn func(transaction.Transaction) error) error {
+func WithinTx(ctx context.Context, db DB, options *transaction.TxOptions, fn func(transaction.Transaction) error) error {
 	return withinTxImpl(db,
 		func(db DB) (transaction.Transaction, error) {
 			return db.BeginTx(ctx, options)

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -287,8 +287,8 @@ var _ = Describe("Otto extension manager", func() {
 			})
 		})
 
-		Context("When extension is running too long after default timelimit overriden", func() {
-			It("should be aborted in the middle of extension with overriden time limit", func() {
+		Context("When extension is running too long after default time limit overridden", func() {
+			It("should be aborted in the middle of extension with overridden time limit", func() {
 				timeoutExtension, err := schema.NewExtension(map[string]interface{}{
 					"id": "timeout_extension",
 					"code": `gohan_register_handler("test_event", function(context) {
@@ -324,7 +324,7 @@ var _ = Describe("Otto extension manager", func() {
 				Expect(timeDuration).Should(BeNumerically("<", time.Millisecond*200))
 			})
 
-			It("should not be aborted in the middle of extension with overriden time limit if the override is for a different event", func() {
+			It("should not be aborted in the middle of extension with overridden time limit if the override is for a different event", func() {
 				timeoutExtension, err := schema.NewExtension(map[string]interface{}{
 					"id": "timeout_extension",
 					"code": `gohan_register_handler("test_event", function(context) {
@@ -1866,6 +1866,7 @@ var _ = Describe("Otto extension manager", func() {
 					`,
 				"path": ".*",
 			})
+			Expect(err).ToNot(HaveOccurred())
 			extensions := []*schema.Extension{hookExtension, extension}
 			env := newEnvironment()
 			Expect(env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, "hook")).To(Succeed())
@@ -1981,6 +1982,7 @@ var _ = Describe("Otto extension manager", func() {
 			env.Sync.Update("/gohan_sync_delete_test", "{}")
 			Expect(env.HandleEvent("test_event", context)).To(Succeed())
 			node, err := env.Sync.Fetch("/gohan_sync_delete_test")
+			Expect(err).To(HaveOccurred())
 			Expect(node).To(BeNil())
 		})
 	})
@@ -2009,6 +2011,7 @@ var _ = Describe("Otto extension manager", func() {
 			env.Sync.Update("/gohan_sync_delete_test/child2", "bar")
 			Expect(env.HandleEvent("test_event", context)).To(Succeed())
 			node, err := env.Sync.Fetch("/gohan_sync_delete_test")
+			Expect(err).To(HaveOccurred())
 			Expect(node).To(BeNil())
 		})
 	})

--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -93,7 +93,7 @@ func resourceTransactionWithContext(ctx middleware.Context, dataStore db.DB, lev
 		originalCtx[k] = v
 	}
 
-	return db.WithinTx(dataStore, context.Background(), &transaction.TxOptions{IsolationLevel: level}, func(tx transaction.Transaction) error {
+	return db.WithinTx(context.Background(), dataStore, &transaction.TxOptions{IsolationLevel: level}, func(tx transaction.Transaction) error {
 		for k := range ctx {
 			delete(ctx, k)
 		}

--- a/server/state_watcher.go
+++ b/server/state_watcher.go
@@ -160,7 +160,7 @@ func (watcher *StateWatcher) StateUpdate(event *gohan_sync.Event) error {
 	resourceID := curSchema.GetResourceIDFromPath(schemaPath)
 	log.Info("Started StateUpdate for %s %s %v", event.Action, event.Key, event.Data)
 
-	return db.WithinTx(watcher.db, context.Background(), &transaction.TxOptions{IsolationLevel: transaction.GetIsolationLevel(curSchema, StateUpdateEventName)},
+	return db.WithinTx(context.Background(), watcher.db, &transaction.TxOptions{IsolationLevel: transaction.GetIsolationLevel(curSchema, StateUpdateEventName)},
 		func(tx transaction.Transaction) error {
 			curResource, err := tx.Fetch(curSchema, transaction.IDFilter(resourceID))
 			if err != nil {
@@ -241,7 +241,7 @@ func (watcher *StateWatcher) MonitoringUpdate(event *gohan_sync.Event) error {
 	resourceID := curSchema.GetResourceIDFromPath(schemaPath)
 	log.Info("Started MonitoringUpdate for %s %s %v", event.Action, event.Key, event.Data)
 
-	return db.WithinTx(watcher.db, context.Background(), &transaction.TxOptions{IsolationLevel: transaction.GetIsolationLevel(curSchema, MonitoringUpdateEventName)},
+	return db.WithinTx(context.Background(), watcher.db, &transaction.TxOptions{IsolationLevel: transaction.GetIsolationLevel(curSchema, MonitoringUpdateEventName)},
 		func(tx transaction.Transaction) error {
 			curResource, err := tx.Fetch(curSchema, transaction.IDFilter(resourceID))
 			if err != nil {

--- a/server/sync_watcher_test.go
+++ b/server/sync_watcher_test.go
@@ -146,12 +146,16 @@ var _ = Describe("Sync watcher test", func() {
 			// Therefore, sorting fetched results by key means the order of called sync update extensions
 			watchKey1a := "/watch/key/1/apple"
 			err := sync.Update(watchKey1a, "{}")
+			Expect(err).ToNot(HaveOccurred())
 			watchKey2a := "/watch/key/2/apple"
 			err = sync.Update(watchKey2a, "{}")
+			Expect(err).ToNot(HaveOccurred())
 			watchKey1b := "/watch/key/1/banana"
 			err = sync.Update(watchKey1b, "{}")
+			Expect(err).ToNot(HaveOccurred())
 			watchKey1c := "/watch/key/1/cherry"
 			err = sync.Update(watchKey1c, "{}")
+			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(1 * time.Second)
 

--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -268,7 +268,7 @@ func TestWatchWithRevision(t *testing.T) {
 	}()
 
 	resp := <-responseChan
-	if resp.Key != path+"/new" || resp.Data["existing"].(bool) != false || resp.Revision != secondRevision{
+	if resp.Key != path+"/new" || resp.Data["existing"].(bool) != false || resp.Revision != secondRevision {
 		t.Fatalf("mismatch response: %+v, expecting /new, existing==false, revision==%d", resp, secondRevision)
 	}
 
@@ -279,7 +279,7 @@ func TestWatchWithRevision(t *testing.T) {
 	thirdRevision := putResponse.Header.Revision
 
 	resp = <-responseChan
-	if resp.Key != path+"/third" || resp.Data["existing"].(bool) != false || resp.Revision != thirdRevision{
+	if resp.Key != path+"/third" || resp.Data["existing"].(bool) != false || resp.Revision != thirdRevision {
 		t.Fatalf("mismatch response: %+v, expecting /third, existing==false, revision==%d", resp, thirdRevision)
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -177,7 +177,10 @@ func DecodeYAMLLibObject(yamlData interface{}) interface{} {
 //GetContent loads file from remote or local
 func GetContent(url string) ([]byte, error) {
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		resp, _ := http.Get(url)
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, err
+		}
 		defer resp.Body.Close()
 		content, err := ioutil.ReadAll(resp.Body)
 		return content, err


### PR DESCRIPTION
Cleared most of the golint and go vet errors.
Remaining errors:
server/state_watcher.go: 100: the watchCancel function is not used on all paths (possible context leak)
server/state_watcher.go:103: this return statement may be reached without using the watchCancel var defined on line 100
server/sync_watcher.go:196: the previousCancel function is not used on all paths (possible context leak)
server/sync_watcher.go:208: this return statement may be reached without using the previousCancel var defined on line 196
sync/etcdv3/etcd.go:50: the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak