### PR TITLE
Recover when unexpected panic in sync_watch extension

### DIFF
--- a/server/sync_watcher.go
+++ b/server/sync_watcher.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cloudwan/gohan/extension"
+	l "github.com/cloudwan/gohan/log"
 	"github.com/cloudwan/gohan/metrics"
 	gohan_sync "github.com/cloudwan/gohan/sync"
 	"github.com/cloudwan/gohan/util"
@@ -295,6 +296,7 @@ func (watcher *SyncWatcher) processSyncWatch(ctx context.Context, path string) e
 }
 
 func (watcher *SyncWatcher) watchExtensionHandler(response *gohan_sync.Event) {
+	defer l.Panic(log)
 	for _, event := range watcher.watchEvents {
 		//match extensions
 		if strings.HasPrefix(response.Key, "/"+event) {


### PR DESCRIPTION
Extension might cause error unexpectedly. Previously, extension called
by sync watcher was executed via job queue. However, we changed the
logic to unuse job queue for sync_watch after PR #490, so now extension
error will stop gohan process with panic. This fix will recover
extension error with error message as job queue task runner did.