### PR TITLE
Enable gohan server during bash completion testing of gohan client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ gen:
 	etc/templates/... \
 	public/...
 
-test:
+test: build
 	@echo -e "$(OK_COLOR)==> Testing$(NO_COLOR)"
-	./tools/test_bashcompletion.sh
+	./tools/test_bash_completion.sh
 	# tests require a build with race flag enabled
 	./tools/build.sh -race
 	./tools/build_go_tests.sh -race

--- a/tools/bash_completion_tests.py
+++ b/tools/bash_completion_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import subprocess
 import unittest
 
@@ -51,7 +51,7 @@ class GohanTestCases(BashCompletionTest):
         self.run_complete(" ","client validate v init-db idb convert conv server srv test_extensions test_ex migrate mig template run test test openapi markdown dot glace-server gsrv help h")
 
     def run_complete(self, command, expected):
-        completion_file="bash_completion"
+        completion_file="bash_completion.sh"
         program="gohan"
         super(GohanTestCases, self).run_complete(completion_file, program, command, expected)
 

--- a/tools/gohan_client_bash_completion.sh
+++ b/tools/gohan_client_bash_completion.sh
@@ -9,7 +9,8 @@ getUn_namedProperties()
 {
     _schema_id=$1
     OIFS=$IFS
-    IFS=$'\n' arr=`${COMP_WORDS[0]} client $_schema_id list`
+    IFS=$'\n'
+    arr=`${COMP_WORDS[0]} client $_schema_id list`
     _wasProperties=0
     _counter=0
     _un_named=""
@@ -22,15 +23,14 @@ getUn_namedProperties()
         _result="${_cop//$_replacewhat/$_replacewith}"
         _result="${_result//$_replacewhat2/$_replacewith}"
         let _counter=_counter+1
-        if [  -z $_result ] ; then
+        if [ -z "$_result" ]; then
             continue
         fi
-        if [[ $_counter -gt 2 ]];then
+        if [ $_counter -gt 2 ];then
             _args=$(echo $a | tr "|" "\n")
             _sub=0
             for i in $_args
             do
-
 		let _sub=_sub+1
 		if [ $_sub -eq 1 ] && [ ! -z "${i// }" ] ; then
         	    i="$(echo -e "${i}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
@@ -38,6 +38,7 @@ getUn_namedProperties()
 		fi
             done
         fi
+    IFS=$OIFS
     done
 }
 
@@ -66,6 +67,7 @@ getProperties()
 	elif [[ -z "${a// }" ]] ; then
             _wasProperties=0
 	fi
+    IFS=$OIFS
     done
 }
 

--- a/tools/gohan_client_bash_completion_tests.py
+++ b/tools/gohan_client_bash_completion_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import subprocess
 import unittest
 
@@ -38,7 +39,6 @@ class BashCompletionTest(unittest.TestCase):
 
     def run_complete(self, completion_file, program, command, expected):
         stdout,stderr = Completion().run(completion_file, program, command)
-        print(stdout)
         self.assertEqual(stdout.decode("utf-8"), expected + '\n')
 
 class GohanClientTestCases(BashCompletionTest):

--- a/tools/template.py
+++ b/tools/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (C) 2015 NTT Innovation Institute, Inc.
 #

--- a/tools/test_bash_completion.sh
+++ b/tools/test_bash_completion.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+GOPATH0=(${GOPATH//:/ })
+GOHANPATH=$GOPATH0/src/github.com/cloudwan/gohan
+
+# sub-bash
+(
+    # run ETCD
+    DATA_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+    etcd -data-dir $DATA_DIR --listen-peer-urls http://:2380 --listen-client-urls http://:2379 --advertise-client-urls http://127.0.0.1:2379 &
+    ETCD_PID=$!
+
+    # wait for ETCD to start
+    while ! echo -n > /dev/tcp/localhost/2379; do sleep 1; done
+
+    # append to path gohan binary path
+    export PATH=$PATH:$GOHANPATH
+
+    # run gohan server
+    gohan server --config-file etc/gohan.yaml &
+    SERVER_PID=$!
+
+    # wait for gohan server to start
+    while ! echo -n > /dev/tcp/localhost/9091; do sleep 1; done
+
+    # configure gohan client
+    source etc/gohan_client.rc
+
+    # enter tools
+    cd tools
+
+    # test bash completion
+    source ./bash_completion.sh
+    ./bash_completion_tests.py
+
+    # test gohan client bash completion
+    source ./gohan_client_bash_completion.sh
+    ./gohan_client_bash_completion_tests.py
+
+    # kill server
+    kill $SERVER_PID
+
+    # kill etcd
+    kill $ETCD_PID
+)

--- a/tools/test_bashcompletion.sh
+++ b/tools/test_bashcompletion.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-cd tools
-./gohan_client_bash_completion.sh
-python3.5.2 gohan_client_bash_completion_tests.py
-cd ..


### PR DESCRIPTION
In order to test bash completion of gohan client, gohan server must be running. It is for example required for completion of resource names.