### PR TITLE
[ESI-14568] Add forced schemas option

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -18,13 +18,17 @@ package cli
 import (
 	"flag"
 	"fmt"
-	"github.com/cloudwan/gohan/sync/etcdv3"
-	"github.com/codegangsta/cli"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/cloudwan/gohan/db/migration"
+	"github.com/cloudwan/gohan/sync/etcdv3"
+	sync_util "github.com/cloudwan/gohan/sync/util"
+	"github.com/cloudwan/gohan/util"
+	"github.com/codegangsta/cli"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 const useEtcdEnv = "USE_ETCD_DURING_MIGRATIONS"
@@ -35,7 +39,7 @@ func getContextWithConfig(configFile string, useEtcd bool) *cli.Context {
 	}
 
 	configFlag := cli.StringFlag{Name: "config-file", Value: configFile}
-	useEtcdFlag := cli.BoolFlag{Name: lockWithEtcd, EnvVar: useEtcdEnv}
+	useEtcdFlag := cli.BoolFlag{Name: FlagLockWithETCD, EnvVar: useEtcdEnv}
 
 	set := flag.NewFlagSet("", flag.ContinueOnError)
 	configFlag.Apply(set)
@@ -83,7 +87,7 @@ var _ = Describe("CLI", func() {
 			Expect(context.String("config-file")).To(Equal(configPath))
 
 			wrapped := func() {
-				migrationSubcommandWithLock(lock)(context)
+				withinLockedMigration(lock)(context)
 				waitForThread.Done()
 			}
 
@@ -107,7 +111,7 @@ var _ = Describe("CLI", func() {
 				waitForThread.Done()
 			}
 
-			wrapped := migrationSubcommandWithLock(func(context *cli.Context) {})
+			wrapped := withinLockedMigration(func(context *cli.Context) {})
 			context := getContextWithConfig(configPath, false)
 			Expect(context.String("config-file")).To(Equal(configPath))
 
@@ -117,6 +121,28 @@ var _ = Describe("CLI", func() {
 			wrapped(context)
 			waitForLocal.Done()
 			waitForThread.Wait()
+		})
+
+		It("Should handle sending post-migration event to forced schemas", func() {
+			set := flag.NewFlagSet("", flag.PanicOnError)
+			cli.StringFlag{Name: FlagForcedSchemas, Value: "force_schema"}.Apply(set)
+			cli.BoolTFlag{Name: FlagEmitPostMigrationEvent}.Apply(set)
+			cli.StringFlag{Name: flagConfigFile, Value: "../tests/test_forced_post_migrate_config.yaml"}.Apply(set)
+			cli.DurationFlag{Name: FlagPostMigrationEventTimeout, Value: time.Duration(60) * time.Second}.Apply(set)
+			context := cli.NewContext(nil, set, &cli.Context{})
+
+			configFile := context.String(flagConfigFile)
+			loadConfig(configFile)
+			Expect(migration.LoadConfig(configFile)).To(Succeed())
+
+			actionMigrateWithPostMigrationEvent("up")(context)
+
+			sync, err := sync_util.CreateFromConfig(util.GetConfig())
+			Expect(err).To(Succeed())
+
+			node, err := sync.Fetch("post-migration")
+			Expect(err).To(Succeed())
+			Expect(node.Value).To(Equal("success"))
 		})
 	})
 })

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -30,7 +30,7 @@ func getGenerateCommand() cli.Command {
 		ShortName: "gen",
 		Usage:     "Generate ServerSide Code",
 		Flags: []cli.Flag{
-			cli.StringFlag{Name: "templates", Value: "", Usage: "Template Configuraion"},
+			cli.StringFlag{Name: "templates", Value: "", Usage: "Template configuration"},
 			cli.StringFlag{Name: "config-file, c", Value: "./gohan.yaml", Usage: "Gohan config file"},
 			cli.StringFlag{Name: "language, l", Value: "go", Usage: "Programming language"},
 			cli.StringFlag{Name: "output, o", Value: ".", Usage: "Dir of output"},
@@ -102,7 +102,7 @@ func gohanGenerate(c *cli.Context) {
 	config.ReadConfig(configFile)
 	schemaFiles := config.GetStringList("schemas", nil)
 	if schemaFiles == nil {
-		log.Fatal("No schema specified in configuraion")
+		log.Fatal("No schema specified in configuration")
 		return
 	}
 	if err := manager.LoadSchemasFromFiles(schemaFiles...); err != nil {

--- a/cli/migrate.go
+++ b/cli/migrate.go
@@ -1,0 +1,307 @@
+// Copyright (C) 2017 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/migration"
+	db_options "github.com/cloudwan/gohan/db/options"
+	db_sql "github.com/cloudwan/gohan/db/sql"
+	"github.com/cloudwan/gohan/extension"
+	"github.com/cloudwan/gohan/extension/otto"
+	"github.com/cloudwan/gohan/schema"
+	"github.com/cloudwan/gohan/server"
+	"github.com/cloudwan/gohan/server/middleware"
+	"github.com/cloudwan/gohan/sync"
+	sync_util "github.com/cloudwan/gohan/sync/util"
+	"github.com/cloudwan/gohan/util"
+	"github.com/codegangsta/cli"
+)
+
+const (
+	// events
+	eventPostMigration = "post-migration"
+
+	// settings
+	syncMigrationsPath   = "/gohan/cluster/migrations"
+	postMigrationEnvName = "post-migration-env"
+
+	// flags
+	FlagEmitPostMigrationEvent    = "emit-post-migration-event"
+	FlagPostMigrationEventTimeout = "post-migration-event-timeout"
+	FlagForcedSchemas             = "forced-schemas"
+	FlagLockWithETCD              = "lock-with-etcd"
+	FlagSyncETCDEvent             = "sync-etcd-event"
+)
+
+func withinLockedMigration(fn func(context *cli.Context)) func(*cli.Context) {
+	return func(context *cli.Context) {
+		configFile := context.String("config-file")
+
+		if migration.LoadConfig(configFile) != nil {
+			return
+		}
+
+		if !context.Bool(FlagLockWithETCD) {
+			fn(context)
+			return
+		}
+
+		config := util.GetConfig()
+		sync, err := sync_util.CreateFromConfig(config)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if sync == nil {
+			log.Fatal("sync is nil")
+		}
+
+		_, err = sync.Lock(syncMigrationsPath, true)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer sync.Unlock(syncMigrationsPath)
+
+		fn(context)
+	}
+}
+
+func selectModifiedSchemas(forcedSchemas string) []string {
+	if len(forcedSchemas) > 0 {
+		return strings.Split(forcedSchemas, ",")
+	}
+	return migration.GetModifiedSchemas()
+}
+
+func emitPostMigrateEvent(forcedSchemas string, syncETCDEvent bool, postMigrationEventTimeout time.Duration) {
+	config := util.GetConfig()
+
+	log.Info("Emit post-migrate event")
+
+	modifiedSchemas := selectModifiedSchemas(forcedSchemas)
+
+	if len(modifiedSchemas) == 0 {
+		log.Info("No modified schemas, skipping post-migration event")
+		return
+	}
+
+	log.Debug("Modified schemas: %s", strings.Join(modifiedSchemas, ", "))
+
+	schemaFiles := config.GetStringList("schemas", nil)
+
+	if schemaFiles == nil {
+		log.Fatal("No schema specified in configuration")
+	}
+
+	manager := schema.GetManager()
+	if err := manager.LoadSchemasFromFiles(schemaFiles...); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := publishEvent(postMigrationEnvName, modifiedSchemas, eventPostMigration, syncETCDEvent, postMigrationEventTimeout); err != nil {
+		log.Fatal("Publish post-migrate event failed: %s", err)
+	}
+
+	schema.ClearManager()
+
+	log.Info("Published post-migrate event: %s", strings.Join(modifiedSchemas, ", "))
+}
+
+func actionMigrate(subcmd string) func(context *cli.Context) {
+	return withinLockedMigration(func(context *cli.Context) {
+		if err := migration.Run(subcmd, context.Args()); err != nil {
+			log.Fatalf("Migrate run failed: %s", err)
+		}
+	})
+}
+
+func actionMigrateWithPostMigrationEvent(subcmd string) func(context *cli.Context) {
+	return withinLockedMigration(func(context *cli.Context) {
+		if err := migration.Run(subcmd, context.Args()); err != nil {
+			log.Fatalf("Migrate run failed: %s", err)
+		}
+		if !context.Bool(FlagEmitPostMigrationEvent) {
+			return
+		}
+		emitPostMigrateEvent(context.String(FlagForcedSchemas), context.Bool(FlagSyncETCDEvent), context.Duration(FlagPostMigrationEventTimeout))
+	})
+}
+
+func actionMigrateHelp() func(context *cli.Context) {
+	return func(context *cli.Context) {
+		migration.Help()
+	}
+}
+
+func actionMigrateCreateInitialMigration() func(context *cli.Context) {
+	return func(c *cli.Context) {
+		schemaFile := c.String("schema")
+		cascade := c.Bool("cascade")
+		manager := schema.GetManager()
+		configFile := c.String("config-file")
+		if configFile != "" {
+			config := util.GetConfig()
+			config.ReadConfig(configFile)
+			schemaFiles := config.GetStringList("schemas", nil)
+			if schemaFiles == nil {
+				log.Fatal("No schema specified in configuration")
+				return
+			}
+			if err := manager.LoadSchemasFromFiles(schemaFiles...); err != nil {
+				log.Fatal(err)
+				return
+			}
+		}
+		if schemaFile != "" {
+			manager.LoadSchemasFromFiles(schemaFile)
+		}
+		name := c.String("name")
+		now := time.Now()
+		version := fmt.Sprintf("%s_%s.sql", now.Format("20060102150405"), name)
+		path := filepath.Join(c.String("path"), version)
+		var sqlString = bytes.NewBuffer(make([]byte, 0, 100))
+		fmt.Printf("Generating goose migration file to %s ...\n", path)
+		sqlDB := db_sql.NewDB(db_options.Default())
+		schemas := manager.OrderedSchemas()
+		sqlString.WriteString("\n")
+		sqlString.WriteString("-- +goose Up\n")
+		sqlString.WriteString("-- SQL in section 'Up' is executed when this migration is applied\n")
+		for _, s := range schemas {
+			if s.IsAbstract() {
+				continue
+			}
+			if s.Metadata["type"] == "metaschema" {
+				continue
+			}
+			createSQL, indices := sqlDB.GenTableDef(s, cascade)
+			sqlString.WriteString(createSQL + "\n")
+			for _, indexSQL := range indices {
+				sqlString.WriteString(indexSQL + "\n")
+			}
+		}
+		sqlString.WriteString("\n")
+		sqlString.WriteString("-- +goose Down\n")
+		sqlString.WriteString("-- SQL section 'Down' is executed when this migration is rolled back\n")
+		for _, s := range schemas {
+			if s.IsAbstract() {
+				continue
+			}
+			if s.Metadata["type"] == "metaschema" {
+				continue
+			}
+			sqlString.WriteString(fmt.Sprintf("drop table %s;", s.GetDbTableName()))
+			sqlString.WriteString("\n\n")
+		}
+		err := ioutil.WriteFile(path, sqlString.Bytes(), os.ModePerm)
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+func publishEventWithOptions(envName string, modifiedSchemas []string, eventName string, syncETCDEvent bool, eventTimeout time.Duration, db *server.DbSyncWrapper, manager *schema.Manager, envManager *extension.Manager, sync sync.Sync, ident middleware.IdentityService) {
+	deadline := time.Now().Add(eventTimeout)
+
+	for _, s := range manager.Schemas() {
+		if !util.ContainsString(modifiedSchemas, s.ID) {
+			continue
+		}
+
+		pluralURL := s.GetPluralURL()
+
+		if _, ok := envManager.GetEnvironment(s.ID); !ok {
+			env := otto.NewEnvironment(envName, db, ident, sync)
+
+			now := time.Now()
+
+			if now.After(deadline) {
+				log.Fatalf("Timeout after '%s' secs while publishing event to schemas", eventTimeout.Seconds())
+			}
+
+			left := deadline.Sub(now)
+
+			env.SetEventTimeLimit(eventName, left)
+			log.Info("Loading environment for %s schema with URL: %s", s.ID, pluralURL)
+
+			if err := env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, pluralURL); err != nil {
+				log.Fatal(fmt.Sprintf("[%s] %v", pluralURL, err))
+			}
+
+			envManager.RegisterEnvironment(s.ID, env)
+		}
+
+		env, _ := envManager.GetEnvironment(s.ID)
+
+		eventContext := map[string]interface{}{}
+		eventContext["schema"] = s
+		eventContext["sync"] = sync
+		eventContext["db"] = db
+		eventContext["identity_service"] = ident
+
+		if err := env.HandleEvent(eventName, eventContext); err != nil {
+			log.Fatalf("Failed to handle event '%s': %s", eventName, err)
+		}
+	}
+
+	if syncETCDEvent {
+		if _, err := server.NewSyncWriter(sync, db).Sync(); err != nil {
+			log.Fatalf("Failed to synchronize post-migration events, err: %s", err)
+		}
+	}
+}
+
+func publishEvent(envName string, modifiedSchemas []string, eventName string, syncETCDEvent bool, eventTimeout time.Duration) error {
+	config := util.GetConfig()
+
+	rawDB, err := db.CreateFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db := &server.DbSyncWrapper{DB: rawDB}
+
+	sync, err := sync_util.CreateFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ident, err := middleware.CreateIdentityServiceFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	envManager := extension.GetManager()
+	manager := schema.GetManager()
+
+	publishEventWithOptions(envName, modifiedSchemas, eventName, syncETCDEvent, eventTimeout, db, manager, envManager, sync, ident)
+
+	return nil
+}

--- a/cli/template.go
+++ b/cli/template.go
@@ -175,7 +175,7 @@ func doTemplate(c *cli.Context) {
 	defer os.Chdir(pwd)
 	schemaFiles := config.GetStringList("schemas", nil)
 	if schemaFiles == nil {
-		util.ExitFatal("No schema specified in configuraion")
+		util.ExitFatal("No schema specified in configuration")
 	} else {
 		err = manager.LoadSchemasFromFiles(schemaFiles...)
 		if err != nil {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,7 +119,7 @@ server schema.
 ### Configuration
 
 Gohan CLI Client is configured though environment variables. Configuration can be divided into few sections.
-You can use default configuraion for client with: source ./etc/gohan_client.rc
+You can use default configuration for client with: source ./etc/gohan_client.rc
 
 ### Keystone
 
@@ -413,7 +413,7 @@ reballanced.
 ## Migrate
 
 gohan migrate command is a simple wrapper for goose command.
-Using gohan migrate command, you can use gohan configuraion to manage 
+Using gohan migrate command, you can use gohan configuration to manage 
 goose based db migraion.
 gohan create command will genenarete initial goose file using schema.
 
@@ -465,7 +465,7 @@ USAGE:
 
 OPTIONS:
    --template, -t                       Application template path
-   --templates                          Template Configuraion
+   --templates                          Template configuration
    --config-file, -c "./gohan.yaml"     Gohan config file
    --output, -o "."                     Dir of output
    --package, -p "gen"                  Package Name
@@ -485,7 +485,7 @@ Prepare gohan.yaml with MySQL configuration
 
 ### Step3
 
-Write template configuraion files. 
+Write template configuration files. 
 
 type can be all, group or resource.
 If type is all, all schema would be included in to a single file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,11 +15,11 @@ Gohan server configuration uses YAML format.
 
 ```yaml
   #######################################################
-  #  Gohan API Server example configuraion
+  #  Gohan API Server example configuration
   ######################################################
 
   include: gohan.d
-  # database connection configuraion
+  # database connection configuration
   database:
       # sqlite3 and mysql supported
       type: "sqlite3"
@@ -54,7 +54,7 @@ Gohan server configuration uses YAML format.
       - "http://127.0.0.1:2379"
   # timeout in milliseconds.1000 milliseconds by default 
   etcd_timeout_ms: 1000
-  # keystone configuraion
+  # keystone configuration
   keystone:
       use_keystone: false
       fake: true
@@ -62,7 +62,7 @@ Gohan server configuration uses YAML format.
       user_name: "admin"
       tenant_name: "admin"
       password: "gohan"
-  # CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+  # CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
   cors: "*"
 
   # Profiling configuration
@@ -112,7 +112,7 @@ You can select from MySQL, sqlite3 and YAML.
 Sample database configuration for MySQL.
 
 ```yaml
-  # database connection configuraion
+  # database connection configuration
   database:
       type: "mysql"
       connection: "root:gohan@127.0.0.1/gohan"
@@ -121,7 +121,7 @@ Sample database configuration for MySQL.
 Sample database configuration for sqlite3.
 
 ```yaml
-  # database connection configuraion
+  # database connection configuration
   database:
       type: "sqlite3"
       connection: "./sqlite3.db"
@@ -255,7 +255,7 @@ Gohan supports OpenStack Keystone authentication backend.
 Gohan supports Cross-Origin Resource Sharing (CORS) for supporting
 javascript WebUI without a proxy server.
 You need to specify allowed domain pattern in CORS parameter.
-Note: DO NOT USE * configuraion in production deployment.
+Note: DO NOT USE * configuration in production deployment.
 
 ```yaml
   cors: "*"

--- a/docs/js_extension.md
+++ b/docs/js_extension.md
@@ -245,10 +245,10 @@ apply go style template
 - gohan_netconf_open(hostname, username)
 
 open netconf session.
-(Note: you need set up ssh key configuraion
+(Note: you need set up ssh key configuration
 on both of gohan and target node.)
 In gohan, you need to setup ssh/key_file
-configuraion.
+configuration.
 
 - gohan_netconf_exec(session, command)
 
@@ -261,10 +261,10 @@ close netconf session
 - gohan_ssh_open(hostname, username)
 
 open ssh session.
-(Note: you need set up ssh key configuraion
+(Note: you need set up ssh key configuration
 on both of gohan and target node.)
 In gohan, you need to setup ssh/key_file
-configuraion.
+configuration.
 
 - gohan_ssh_exec(session, command)
 

--- a/etc/gohan.yaml
+++ b/etc/gohan.yaml
@@ -1,5 +1,5 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
 # database connection configuration
@@ -36,12 +36,15 @@ tls:
 # document root of gohan API server
 # embedded webui get served if you use "embed" here
 document_root: "embed"
+
 # list of etcd backend servers
 etcd:
     - "http://127.0.0.1:2379"
+
 # timeout in milliseconds.1000 milliseconds by default
 etcd_timeout_ms: 1000
-# keystone configuraion
+
+# keystone configuration
 keystone:
     use_keystone: false
     fake: true
@@ -50,6 +53,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
+
 # CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
 # cors: "*"
 

--- a/etc/heroku.yaml
+++ b/etc/heroku.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -32,7 +32,7 @@ document_root: "embed"
 # list of etcd backend servers
 #etcd:
 #    - "http://127.0.0.1:2379"
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -40,7 +40,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 webui_config:

--- a/etc/schema/gohan.json
+++ b/etc/schema/gohan.json
@@ -294,7 +294,7 @@
                                                 "type": "boolean"
                                             },
                                             "view": {
-                                                "title": "view configuraion on UI",
+                                                "title": "view configuration on UI",
                                                 "type": "array"
                                             }
                                         },

--- a/etc/templates/server.tmpl
+++ b/etc/templates/server.tmpl
@@ -124,7 +124,7 @@ func RunServer(configFile string, controller ControllerInterface) {
 	maxConn := config.GetInt("database/max_open_conn", defaultMaxOpenConn)
 	if databaseConnection == "" {
 		fatalError(
-			fmt.Errorf("no database connection specified in the configuraion file"))
+			fmt.Errorf("no database connection specified in the configuration file"))
 	}
 	db, err := sql.Open(databaseType, databaseConnection)
 	fatalError(err)

--- a/examples/cron_example/gohan.yaml
+++ b/examples/cron_example/gohan.yaml
@@ -1,5 +1,5 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
 database:
@@ -15,7 +15,7 @@ editable_schema: ./example_schema.yaml
 
 address: ":9091"
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true

--- a/examples/db_migration/README.md
+++ b/examples/db_migration/README.md
@@ -10,7 +10,7 @@ However, Gohan provides helper utility to generate migration file.
 Step1
 -------
 
-Prepare goose configuraion file.
+Prepare goose configuration file.
 We have a example in db/dbconf.yml
 
 ``` yaml

--- a/examples/db_migration/gohan.yaml
+++ b/examples/db_migration/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -27,7 +27,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -35,7 +35,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/examples/etcd_worker_example/gohan.yaml
+++ b/examples/etcd_worker_example/gohan.yaml
@@ -1,5 +1,5 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
 database:
@@ -16,7 +16,7 @@ editable_schema: ./example_schema.yaml
 
 address: ":9091"
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true

--- a/examples/go_example/gohan.yaml
+++ b/examples/go_example/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -28,7 +28,7 @@ tls:
 # list of etcd backend servers
 etcd:
     - "http://127.0.0.1:2379"
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -36,7 +36,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/examples/keystone/gohan.yaml
+++ b/examples/keystone/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -27,7 +27,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: false
@@ -35,7 +35,7 @@ keystone:
     user_name: "gohan"
     tenant_name: "service"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -8,13 +8,13 @@ You can run gohan + mysql with this command.
 MYSQL_PASSWORD=$MYSQL_PASSWORD gohan server --config-file gohan.yaml
 
 ``` yaml
-# database connection configuraion
+# database connection configuration
 database:
     type: "mysql"
     connection: "root:{{.MYSQL_PASSWORD}}@/gohan"
 ```
 
-You can see more mysql configuraion here
+You can see more mysql configuration here
 https://github.com/go-sql-driver/mysql
 
 Simple test script

--- a/examples/mysql/gohan.yaml
+++ b/examples/mysql/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     type: "mysql"
     connection: "root:{{.MYSQL_PASSWORD}}@/gohan"
@@ -24,7 +24,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -32,7 +32,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 etcd:

--- a/examples/noauth/gohan.yaml
+++ b/examples/noauth/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -28,7 +28,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -36,7 +36,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/examples/npm_example/gohan.yaml
+++ b/examples/npm_example/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -36,7 +36,7 @@ document_root: "embed"
 # list of etcd backend servers
 #etcd:
 #    - "http://127.0.0.1:2379"
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: false
     fake: true
@@ -45,7 +45,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 # cors: "*"
 
 # Generate webui config

--- a/examples/policy/gohan.yaml
+++ b/examples/policy/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -28,7 +28,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -36,7 +36,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/examples/relation_sample/gohan.yaml
+++ b/examples/relation_sample/gohan.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -27,7 +27,7 @@ tls:
     key_file: ./key.pem
     cert_file: ./cert.pem
 
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -35,7 +35,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/extension/gohanscript/lib/gohan.go
+++ b/extension/gohanscript/lib/gohan.go
@@ -93,7 +93,7 @@ func GohanPolicies() []*schema.Policy {
 	return manager.Policies()
 }
 
-//ReadConfig reads configuraion from file.
+//ReadConfig reads configuration from file.
 func ReadConfig(path string) error {
 	config := util.GetConfig()
 	err := config.ReadConfig(path)

--- a/schema/extension.go
+++ b/schema/extension.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cloudwan/gohan/util"
 )
 
-//DefaultExtension configuraion
+//DefaultExtension configuration
 var DefaultExtension = "javascript"
 
 //Extension is a small plugin for gohan

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,7 @@ func (server *Server) getDatabaseConfig() (string, string, bool, bool, bool) {
 	}
 	databaseConnection := config.GetString("database/connection", "")
 	if databaseConnection == "" {
-		log.Fatal("no database connection specified in the configuraion file.")
+		log.Fatal("no database connection specified in the configuration file.")
 	}
 	databaseDropOnCreate := config.GetBool("database/drop_on_create", false)
 	databaseCascade := config.GetBool("database/cascade_delete", false)
@@ -274,7 +274,7 @@ func NewServer(configFile string) (*Server, error) {
 
 	schemaFiles := config.GetStringList("schemas", nil)
 	if schemaFiles == nil {
-		log.Fatal("No schema specified in configuraion")
+		log.Fatal("No schema specified in configuration")
 	} else {
 		err = manager.LoadSchemasFromFiles(schemaFiles...)
 		if err != nil {

--- a/tests/test_forced_post_migrate_config.yaml
+++ b/tests/test_forced_post_migrate_config.yaml
@@ -1,0 +1,28 @@
+database:
+    type: "sqlite3"
+    connection: "./gohan.db"
+    drop_on_create: true
+schemas:
+    - "embed://etc/schema/gohan.json"
+    - "embed://etc/extensions/gohan_extension.yaml"
+    - "./test_forced_post_migrate_schema.yaml"
+address: ":9091"
+tls:
+    enabled: false
+    key_file: ./keys/key.pem
+    cert_file: ./keys/cert.pem
+document_root: "."
+etcd:
+    - "http://127.0.0.1:2379"
+keystone:
+    use_keystone: true
+    fake: true
+    auth_url: "https://localhost:9091/v2.0"
+    user_name: "admin"
+    tenant_name: "admin"
+    password: "gohan"
+cors: "*"
+logging:
+    stderr:
+        enabled: true
+        level: DEBUG

--- a/tests/test_forced_post_migrate_schema.yaml
+++ b/tests/test_forced_post_migrate_schema.yaml
@@ -1,0 +1,18 @@
+schemas:
+- description: force_schema
+  id: force_schema
+  singular: force_schema
+  plural: force_schemas
+  title: force_schema
+  schema:
+    properties:
+      id:
+        description: ID
+        title: ID
+        type: string
+    type: object
+extensions:
+- id: test_force_schema
+  code_type: javascript
+  path: .*
+  code: "gohan_register_handler(\"post-migration\", function(context) { gohan_sync_update(\"post-migration\", \"success\"); });"

--- a/tests/test_worker.yaml
+++ b/tests/test_worker.yaml
@@ -1,8 +1,8 @@
 #######################################################
-#  Gohan API Server example configuraion
+#  Gohan API Server example configuration
 ######################################################
 
-# Sample Configuraion for testing worker condition we get 401 from etcd
+# Sample configuration for testing worker condition we get 401 from etcd
 # TODO(nati) automate this
 #
 # How to test worker
@@ -19,7 +19,7 @@
 # (7) You should be able to see 20000 lines after some time
 
 
-# database connection configuraion
+# database connection configuration
 database:
     # yaml, json, sqlite3 and mysql supported
     # yaml and json db is for schema development purpose
@@ -51,7 +51,7 @@ document_root: "."
 # list of etcd backend servers
 etcd:
     - "http://127.0.0.1:2379"
-# keystone configuraion
+# keystone configuration
 keystone:
     use_keystone: true
     fake: true
@@ -59,7 +59,7 @@ keystone:
     user_name: "admin"
     tenant_name: "admin"
     password: "gohan"
-# CORS (Cross-origin resource sharing (CORS)) configuraion for javascript based client
+# CORS (Cross-origin resource sharing (CORS)) configuration for javascript based client
 cors: "*"
 
 # allowed levels  "CRITICAL", "ERROR", "WARNING", "NOTICE", "INFO", "DEBUG",

--- a/util/config.go
+++ b/util/config.go
@@ -28,7 +28,7 @@ type Config struct {
 
 var gohanConfig *Config
 
-//GetConfig returns configuraion data
+//GetConfig returns configuration data
 func GetConfig() *Config {
 	if gohanConfig == nil {
 		config := map[string]interface{}{}


### PR DESCRIPTION
This change adds an additional flag to specify a list of schemas to which
send a post-migration event during migration, even if those schemas were not
modified during migration.
    
Example usage:
`gohan migrate up --config-file gohan.yaml --forced-schemas pet,plant --emit-post-migration-event`