### PR TITLE
CI for crosscompile fix

### DIFF
--- a/extension/goext/schemas.go
+++ b/extension/goext/schemas.go
@@ -94,7 +94,7 @@ func (ctx Context) Clone() Context {
 }
 
 // Priority represents handler priority; can be negative
-type Priority = int
+type Priority int
 
 // PriorityDefault is a default handler priority
 const PriorityDefault Priority = 0


### PR DESCRIPTION
crosscompile.sh execution failed due to syntax error for windows with
following error message.

extension/goext/schemas.go:97: syntax error: unexpected = in type
declaration

Curiously, compile error did not happen for go1.9 on linux. However,
apparently this declaration is weird, so that should be better to fix
this line.