### PR TITLE
Propagate error code from exceptions thrown by extensions

### DIFF
--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -1098,6 +1098,8 @@ var _ = Describe("Otto extension manager", func() {
 							Expect(env.HandleEvent("test", context)).To(Succeed())
 							Expect(context["exception"]).To(HaveKeyWithValue("message", ContainSubstring("Labori inteligente")))
 							Expect(context["exception_message"]).To(ContainSubstring("Labori inteligente"))
+							innerException := context["exception"].(map[string]interface{})["inner_exception"].(map[string]interface{})
+							Expect(innerException).To(HaveKeyWithValue("code", int64(390)))
 						})
 					})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -701,6 +701,11 @@ var _ = Describe("Server package test", func() {
 			Expect(result).To(Equal("Dobranoc!"))
 		})
 
+		It("should propagare custom errors", func() {
+			result := testURL("GET", responderPluralURL+"/r1/test_throw", memberTokenID, nil, 499)
+			Expect(result.(map[string]interface{})).To(HaveKeyWithValue("error", "tested exception"))
+		})
+
 		It("should be unauthorized", func() {
 			testHiAction := map[string]interface{}{
 				"name": "Heisenberg",

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -25,6 +25,18 @@ extensions:
     });
   id: test
   path: /v2.0/responder
+- code: |
+    gohan_register_handler("test_throw", function (context) {
+        function ValidationException(msg) {
+            CustomException.call(this, msg, 499);
+            this.name = "ValidationException";
+        }
+        ValidationException.prototype = Object.create(CustomException.prototype);
+
+        throw new ValidationException("tested exception");
+    });
+  id: test
+  path: /v2.0/responder
 
 
 networks: []
@@ -45,6 +57,12 @@ policies:
 - action: dobranoc
   effect: allow
   id: member_dobranoc
+  principal: Member
+  resource:
+    path: /v2.0/responder.*
+- action: test_throw
+  effect: allow
+  id: member_test_throw
   principal: Member
   resource:
     path: /v2.0/responder.*
@@ -431,6 +449,11 @@ schemas:
     dobranoc:
       method: GET
       path: /:id/dobranoc
+      output:
+        type: string
+    test_throw:
+      method: GET
+      path: /:id/test_throw
       output:
         type: string
 - description: ResponderParent


### PR DESCRIPTION
This PR fixes a bug where error codes set in custom JS exceptions were not propagated to the API user. Custom JS exceptions may be constructed according to https://github.com/cloudwan/gohan/blob/master/docs/js_extension.md, section "Build in exception types", example "ValidationException".