### PR TITLE
Remove Priority type

### DIFF
--- a/extension/goext/core.go
+++ b/extension/goext/core.go
@@ -22,6 +22,6 @@ type ICore interface {
 	TriggerEvent(event string, context Context) error
 	HandleEvent(event string, context Context) error
 
-	RegisterEventHandler(eventName string, handler func(context Context, environment IEnvironment) error, priority Priority)
-	RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context Context, resource Resource, environment IEnvironment) error, priority Priority)
+	RegisterEventHandler(eventName string, handler func(context Context, environment IEnvironment) error, priority int)
+	RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context Context, resource Resource, environment IEnvironment) error, priority int)
 }

--- a/extension/goext/schemas.go
+++ b/extension/goext/schemas.go
@@ -93,11 +93,8 @@ func (ctx Context) Clone() Context {
 	return contextCopy
 }
 
-// Priority represents handler priority; can be negative
-type Priority = int
-
 // PriorityDefault is a default handler priority
-const PriorityDefault Priority = 0
+const PriorityDefault = 0
 
 // ISchema is an interface representing a single schema in Gohan
 type ISchema interface {
@@ -140,7 +137,7 @@ type ISchema interface {
 	DeleteRaw(filter Filter, context Context) error
 
 	// RegisterEventHandler registers an event handler for a named event with given priority
-	RegisterEventHandler(event string, handler func(context Context, resource Resource, environment IEnvironment) error, priority Priority)
+	RegisterEventHandler(event string, handler func(context Context, resource Resource, environment IEnvironment) error, priority int)
 
 	// RegisterType registers a resource type, derived from BaseResource
 	RegisterType(resourceType interface{})

--- a/extension/goplugin/core.go
+++ b/extension/goplugin/core.go
@@ -27,12 +27,12 @@ type Core struct {
 }
 
 // RegisterSchemaEventHandler registers a schema handler
-func (thisCore *Core) RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority goext.Priority) {
+func (thisCore *Core) RegisterSchemaEventHandler(schemaID string, eventName string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority int) {
 	thisCore.environment.RegisterSchemaEventHandler(schemaID, eventName, handler, priority)
 }
 
 // RegisterEventHandler registers a global handler
-func (thisCore *Core) RegisterEventHandler(eventName string, handler func(context goext.Context, environment goext.IEnvironment) error, priority goext.Priority) {
+func (thisCore *Core) RegisterEventHandler(eventName string, handler func(context goext.Context, environment goext.IEnvironment) error, priority int) {
 	thisCore.environment.RegisterEventHandler(eventName, handler, priority)
 }
 

--- a/extension/goplugin/environment.go
+++ b/extension/goplugin/environment.go
@@ -45,7 +45,7 @@ type Handler func(context goext.Context, environment goext.IEnvironment) error
 type Handlers []Handler
 
 // PrioritizedHandlers is a prioritized list of generic handlers
-type PrioritizedHandlers map[goext.Priority]Handlers
+type PrioritizedHandlers map[int]Handlers
 
 // EventPrioritizedHandlers is a per-event prioritized list of generic handlers
 type EventPrioritizedHandlers map[string]PrioritizedHandlers
@@ -57,7 +57,7 @@ type SchemaHandler func(context goext.Context, resource goext.Resource, environm
 type SchemaHandlers []SchemaHandler
 
 // PrioritizedSchemaHandlers is a prioritized list of schema handlers
-type PrioritizedSchemaHandlers map[goext.Priority]SchemaHandlers
+type PrioritizedSchemaHandlers map[int]SchemaHandlers
 
 // SchemaPrioritizedSchemaHandlers is a per-schema prioritized list of schema handlers
 type SchemaPrioritizedSchemaHandlers map[string]PrioritizedSchemaHandlers
@@ -322,8 +322,8 @@ func (thisEnvironment *Environment) dispatchSchemaEvent(prioritizedSchemaHandler
 	return nil
 }
 
-func sortSchemaHandlers(schemaHandlers PrioritizedSchemaHandlers) []goext.Priority {
-	priorities := []goext.Priority{}
+func sortSchemaHandlers(schemaHandlers PrioritizedSchemaHandlers) (priorities []int) {
+	priorities = []int{}
 	for priority := range schemaHandlers {
 		priorities = append(priorities, priority)
 	}
@@ -331,8 +331,8 @@ func sortSchemaHandlers(schemaHandlers PrioritizedSchemaHandlers) []goext.Priori
 	return priorities
 }
 
-func sortHandlers(handlers PrioritizedHandlers) []goext.Priority {
-	priorities := []goext.Priority{}
+func sortHandlers(handlers PrioritizedHandlers) (priorities []int) {
+	priorities = []int{}
 	for priority := range handlers {
 		priorities = append(priorities, priority)
 	}
@@ -548,7 +548,7 @@ func (thisEnvironment *Environment) resourceFromContext(sch Schema, context map[
 }
 
 // RegisterEventHandler registers an event handler
-func (thisEnvironment *Environment) RegisterEventHandler(event string, handler func(context goext.Context, environment goext.IEnvironment) error, priority goext.Priority) {
+func (thisEnvironment *Environment) RegisterEventHandler(event string, handler func(context goext.Context, environment goext.IEnvironment) error, priority int) {
 	if GlobHandlers == nil {
 		GlobHandlers = EventPrioritizedHandlers{}
 	}
@@ -565,7 +565,7 @@ func (thisEnvironment *Environment) RegisterEventHandler(event string, handler f
 }
 
 // RegisterSchemaEventHandler register an event handler for a schema
-func (thisEnvironment *Environment) RegisterSchemaEventHandler(schemaID string, event string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority goext.Priority) {
+func (thisEnvironment *Environment) RegisterSchemaEventHandler(schemaID string, event string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority int) {
 	if GlobSchemaHandlers == nil {
 		GlobSchemaHandlers = EventSchemaPrioritizedSchemaHandlers{}
 	}

--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -593,7 +593,7 @@ func (thisSchema *Schema) DeleteRaw(filter goext.Filter, context goext.Context) 
 }
 
 // RegisterEventHandler registers a schema handler
-func (thisSchema *Schema) RegisterEventHandler(event string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority goext.Priority) {
+func (thisSchema *Schema) RegisterEventHandler(event string, handler func(context goext.Context, resource goext.Resource, environment goext.IEnvironment) error, priority int) {
 	thisSchema.environment.RegisterSchemaEventHandler(thisSchema.rawSchema.ID, event, handler, priority)
 }
 


### PR DESCRIPTION
Since Priority is just an alias of int and there is no additional
restrictions on top of int, we simply use int here.