### PR TITLE
Omit returning error during deletion of non existing resource

### DIFF
--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -597,13 +597,9 @@ func (schema *Schema) delete(filter goext.Filter, context goext.Context, trigger
 	if err != nil {
 		return err
 	}
-	fetchedLen := len(fetched)
-	if fetchedLen == 0 {
-		return fmt.Errorf("resource not found")
-	}
 
 	mapper := reflectx.NewMapper("db")
-	for i := 0; i < fetchedLen; i++ {
+	for i := 0; i < len(fetched); i++ {
 		resource := reflect.ValueOf(fetched[i])
 		resourceID := mapper.FieldByName(resource, "id").Interface()
 

--- a/extension/goplugin/schemas_test.go
+++ b/extension/goplugin/schemas_test.go
@@ -177,6 +177,10 @@ var _ = Describe("Schemas", func() {
 				_, err := testSchema.LockListRaw(goext.Filter{"id": unknownID}, nil, context, goext.SkipRelatedResources)
 				Expect(err).To(Succeed())
 			})
+
+			It("Should not return error in DeleteRaw", func() {
+				Expect(testSchema.DeleteRaw(goext.Filter{"id": unknownID}, context)).To(Succeed())
+			})
 		})
 
 	})


### PR DESCRIPTION
JS extensions doesn't throw ResourceNotFoundException when user tries to delete resource which doesn't exist in DB. 

Go should have same semantic.