### PR TITLE
Each instance of logger has different TraceID

### DIFF
--- a/extension/goplugin/core.go
+++ b/extension/goplugin/core.go
@@ -64,11 +64,11 @@ func NewCore(env *Environment) *Core {
 }
 
 // Clone allocates a clone of Core; object may be nil
-func (core *Core) Clone() *Core {
+func (core *Core) Clone(env *Environment) *Core {
 	if core == nil {
 		return nil
 	}
 	return &Core{
-		env: core.env,
+		env: env,
 	}
 }

--- a/extension/goplugin/logger.go
+++ b/extension/goplugin/logger.go
@@ -139,11 +139,11 @@ func NewLogger(env IEnvironment) *Logger {
 }
 
 // Clone allocates a clone of Logger; object may be nil
-func (logger *Logger) Clone() *Logger {
+func (logger *Logger) Clone(env *Environment) *Logger {
 	if logger == nil {
 		return nil
 	}
 	return &Logger{
-		env: logger.env,
+		env: env,
 	}
 }

--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -103,12 +103,12 @@ func NewSchemas(env IEnvironment) *Schemas {
 }
 
 // Clone allocates a clone of Schemas; object may be nil
-func (schemas *Schemas) Clone() *Schemas {
+func (schemas *Schemas) Clone(env *Environment) *Schemas {
 	if schemas == nil {
 		return nil
 	}
 	return &Schemas{
-		env: schemas.env,
+		env: env,
 	}
 }
 


### PR DESCRIPTION
Because logger Clone literally cloned object, same environment was always passed to logger. This resulted that each logger had same traceID. Now Clone generates new traceID for each instance.