### PR TITLE
Don't lock resources during delete

### DIFF
--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -606,7 +606,7 @@ func (schema *Schema) delete(filter goext.Filter, requestContext goext.Context, 
 	contextTx := goext.MakeContext()
 	contextSetTransaction(contextTx, tx)
 
-	fetched, err := schema.LockListRaw(filter, nil, contextTx, goext.LockRelatedResources)
+	fetched, err := schema.ListRaw(filter, nil, contextTx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There's a couple of problems with locking:
- deadlocks may (and will) appear
- locking related resources is too course-grained: it may lock all resources belonging to given tenant