### PR TITLE
Adding order_properties_before to schema

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,6 +21,7 @@ Schemas might also have any of the following optional properties.
 - metadata  -- application specific schema metadata (object)
 - type      -- can be an abstract or empty string (see more in schema inheritance)
 - extends   -- list of base schemas
+- order_properties_before -- to order properties before properties of extended schemas. 
 
 ## Schema Inheritance
 
@@ -357,6 +358,9 @@ eg.
           type: object
           unique: false
 ```
+- order_properties_before
+
+  when resource is extended using 'extends' by default all properties of extended schema gets ordered before the current schema properties. Use this field to order current resource properties before extended resource properties.
 
 ## Indexes
 

--- a/etc/schema/gohan.json
+++ b/etc/schema/gohan.json
@@ -60,6 +60,17 @@
                             "type": "string"
                         }
                     },
+                    "order_properties_before": {
+                        "description": "properties will be ordered before extended properties",
+                        "permission": [
+                            "create"
+                        ],
+                        "title": "Order Properties Before",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "metadata": {
                         "default": {},
                         "description": "metadata for application developer",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -50,6 +50,7 @@ type Schema struct {
 	RawData                        interface{}
 	IsolationLevel                 map[string]interface{}
 	OnParentDeleteCascade          bool
+	OrderPropertiesBefore          []string
 }
 
 const (
@@ -86,12 +87,13 @@ func (e *typeAssertionError) Error() string {
 //NewSchema is a constructor for a schema
 func NewSchema(id, plural, title, description, singular string) *Schema {
 	schema := &Schema{
-		ID:          id,
-		Title:       title,
-		Plural:      plural,
-		Description: description,
-		Singular:    singular,
-		Extends:     []string{},
+		ID:                    id,
+		Title:                 title,
+		Plural:                plural,
+		Description:           description,
+		Singular:              singular,
+		Extends:               []string{},
+		OrderPropertiesBefore: []string{},
 	}
 	return schema
 }
@@ -150,6 +152,7 @@ func newSchemaFromObj(rawTypeData interface{}, metaschema *Schema) (*Schema, err
 
 	schema.Metadata = util.MaybeMap(typeData["metadata"])
 	schema.Extends = util.MaybeStringList(typeData["extends"])
+	schema.OrderPropertiesBefore = util.MaybeStringList(typeData["order_properties_before"])
 
 	actions := util.MaybeMap(typeData["actions"])
 	schema.Actions = []Action{}
@@ -591,9 +594,15 @@ func (schema *Schema) Extend(fromSchema *Schema) error {
 		util.MaybeMap(schema.JSONSchema["properties"]),
 		util.MaybeMap(fromSchema.JSONSchema["properties"]))
 
-	schema.JSONSchema["propertiesOrder"] = util.ExtendStringList(
-		util.MaybeStringList(fromSchema.JSONSchema["propertiesOrder"]),
-		util.MaybeStringList(schema.JSONSchema["propertiesOrder"]))
+	if util.ContainsString(util.MaybeStringList(schema.OrderPropertiesBefore), fromSchema.ID) {
+		schema.JSONSchema["propertiesOrder"] = util.ExtendStringList(
+			util.MaybeStringList(schema.JSONSchema["propertiesOrder"]),
+			util.MaybeStringList(fromSchema.JSONSchema["propertiesOrder"]))
+	} else {
+		schema.JSONSchema["propertiesOrder"] = util.ExtendStringList(
+			util.MaybeStringList(fromSchema.JSONSchema["propertiesOrder"]),
+			util.MaybeStringList(schema.JSONSchema["propertiesOrder"]))
+	}
 
 	schema.JSONSchema["required"] = util.ExtendStringList(
 		util.MaybeStringList(fromSchema.JSONSchema["required"]),

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -16,6 +16,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/cloudwan/gohan/util"
@@ -157,6 +158,63 @@ var _ = Describe("Schema", func() {
 			Expect(bestInTownIdx).ToNot(Equal(-1))
 			Expect(patronIdx).ToNot(Equal(-1))
 			Expect(bestInTownIdx).Should(BeNumerically("<", patronIdx))
+		})
+
+		AfterEach(func() {
+			ClearManager()
+		})
+	})
+
+	Describe("Order properties before", func() {
+		var manager *Manager
+		type JSONSchema struct {
+			PropertiesOrder []string `json:"propertiesOrder"`
+		}
+		var jsonSchema *JSONSchema
+
+		index := func(properties []string, id string) int {
+			for i, property := range properties {
+				if property == id {
+					return i
+				}
+			}
+			return -1
+		}
+
+		BeforeEach(func() {
+			manager = GetManager()
+			Expect(manager.LoadSchemaFromFile(
+				"../tests/test_schema_order_properties_before.yaml")).To(Succeed())
+			jsonSchema = &JSONSchema{}
+			s, ok := manager.Schema("school")
+			Expect(ok).To(BeTrue())
+			js, _ := json.Marshal(s.JSONSchema)
+			json.Unmarshal(js, jsonSchema)
+		})
+
+		It("should list all extends properties in PropertiesOrder", func() {
+			idIdx := index(jsonSchema.PropertiesOrder, "id")
+			nameIdx := index(jsonSchema.PropertiesOrder, "name")
+			fundingIdx := index(jsonSchema.PropertiesOrder, "funding")
+			fmt.Println(jsonSchema.PropertiesOrder, idIdx, nameIdx, fundingIdx)
+			Expect(idIdx).ToNot(Equal(-1))
+			Expect(nameIdx).ToNot(Equal(-1))
+			Expect(fundingIdx).ToNot(Equal(-1))
+		})
+
+		It("should order properties before order_properties_before in PropertiesOrder", func() {
+			nameIdx := index(jsonSchema.PropertiesOrder, "name")
+			bestInTownIdx := index(jsonSchema.PropertiesOrder, "best_in_town")
+			fundingIdx := index(jsonSchema.PropertiesOrder, "funding")
+			Expect(nameIdx).ToNot(Equal(-1))
+			Expect(bestInTownIdx).ToNot(Equal(-1))
+			Expect(fundingIdx).ToNot(Equal(-1))
+			Expect(nameIdx).Should(BeNumerically("<", bestInTownIdx))
+			Expect(bestInTownIdx).Should(BeNumerically("<", fundingIdx))
+		})
+
+		AfterEach(func() {
+			ClearManager()
 		})
 	})
 

--- a/tests/test_schema_order_properties_before.yaml
+++ b/tests/test_schema_order_properties_before.yaml
@@ -1,0 +1,112 @@
+schemas:
+
+- id: base_resource
+  type: abstract
+  description: Resource Base
+  singular: base_resource
+  plural: base_resource
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        view:
+        - detail
+      name:
+        description: Name
+        permission:
+        - create
+        - update
+        title: Name
+        type: string
+    propertiesOrder:
+    - id
+    - name
+    type: object
+  title: Base
+
+- id: affiliation
+  type: abstract
+  description: School Affiliation
+  singular: affiliation
+  plural: affiliation
+  prefix: /v1.0
+  schema:
+    properties:
+      funding:
+        description: Funding
+        enum:
+        - public
+        - private
+        nullable: false
+        permission:
+        - create
+        - update
+        title: Funding
+        type: string
+        view:
+        - detail
+    propertiesOrder:
+    - funding
+    type: object
+  title: Affiliation
+
+- id: city
+  description: City
+  singular: city
+  plural: cities
+  title: City
+  prefix: /v1.0
+  schema:
+    properties:
+      id:
+        description: The ID of City
+        title: ID
+        type: string
+        permission:
+        - create
+      name:
+        description: Name
+        title: Name
+        type: string
+        permission:
+        - create
+    propertiesOrder:
+    - id
+    - name
+    type: object
+
+- id: school
+  description: School
+  singular: school
+  extends:
+    - base_resource
+    - affiliation
+  order_properties_before:
+    - affiliation
+  plural: schools
+  title: School
+  prefix: /v1.0
+  schema:
+    properties:
+      city_id:
+        description: City
+        title: City
+        type: string
+        relation: city
+        relation_property: city
+        permission:
+        - create
+      patron:
+        type: string
+      best_in_town:
+        type: bool
+    propertiesOrder:
+    - city_id
+    - patron
+    - best_in_town
+    type: object


### PR DESCRIPTION
- This is to support ordering Properties of model which extends other models.
- Properties of schema listed under Extends will be ordered after current model properties if they're listed under order_properties_before. so the final order of properties is
properties of extends (not listed in order_properties_before)
current properties
properties of rest of extends model