### PR TITLE
Pending non-deterministic test

### DIFF
--- a/server/sync_watcher_test.go
+++ b/server/sync_watcher_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Sync watcher test", func() {
 
 	Describe("Sync watch load balancing with HA", func() {
 
-		It("should be load balanced based on process number", func() {
+		PIt("should be load balanced based on process number", func() {
 			// Run as Single Node
 			sync := server.GetSync()
 			prn, err := sync.Fetch(processPathPrefix)


### PR DESCRIPTION
Sometimes, sync watcher test failed undeterministically. Set it as a
pending until it's properly fixed.