### PR TITLE
Make ErrMissingType more informative

### DIFF
--- a/extension/goplugin/test_data/test_schema.yaml
+++ b/extension/goplugin/test_data/test_schema.yaml
@@ -139,3 +139,30 @@ schemas:
   schema:
     properties: {}
     type: object
+- description: Schema without registered extensions and not registered as a type
+  id: test_schema_no_ext
+  plural: test_schema_no_exts
+  prefix: /v0.1
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: false
+      name:
+        description: ""
+        permission:
+        - create
+        - update
+        title: Name
+        type: string
+        maxLength: 255
+    propertiesOrder:
+    - id
+    - name
+    type: object
+  singular: test_schema_no_ext
+  title: Test schema without extensions


### PR DESCRIPTION
It happens the the error message "resource type not registered" gets printed in the logs, but this message is not informative because it's hard to tell which resource type is missing.

I was thinking of a panic() instead of returning an error, but finally I've decided not to change the API. Reviewers, what's your opinion about it?