### PR TITLE
Ensure all goext resources inherit IResourceBase

### DIFF
--- a/extension/goext/environment.go
+++ b/extension/goext/environment.go
@@ -35,11 +35,38 @@ type IEnvironment interface {
 	Reset()
 }
 
-// ResourceBase is the base class for all resources
+// ResourceBase is the implementation of base class for all resources
 type ResourceBase struct {
-	Environment IEnvironment
-	Logger      ILogger
-	Schema      ISchema
+	environment IEnvironment
+	schema      ISchema
+	logger      ILogger
+}
+
+func (resourceBase *ResourceBase) Environment() IEnvironment {
+	return resourceBase.environment
+}
+
+func (resourceBase *ResourceBase) Logger() ILogger {
+	return resourceBase.logger
+}
+
+func (resourceBase *ResourceBase) Schema() ISchema {
+	return resourceBase.schema
+}
+
+func NewResourceBase(env IEnvironment, schema ISchema, logger ILogger) *ResourceBase {
+	return &ResourceBase{
+		environment: env,
+		schema:      schema,
+		logger:      logger,
+	}
+}
+
+// IResourceBase is the base class for all resources
+type IResourceBase interface {
+	Environment() IEnvironment
+	Schema() ISchema
+	Logger() ILogger
 }
 
 // NullString represents a nullable string

--- a/extension/goext/schemas.go
+++ b/extension/goext/schemas.go
@@ -168,8 +168,8 @@ type ISchema interface {
 	// RegisterEventHandler registers an event handler for a named event with given priority
 	RegisterEventHandler(event string, handler func(context Context, resource Resource, environment IEnvironment) error, priority int)
 
-	// RegisterType registers a resource type, derived from BaseResource
-	RegisterType(resourceType interface{})
+	// RegisterType registers a resource type, derived from IResourceBase
+	RegisterType(resourceType IResourceBase)
 
 	// RegisterRawType registers a raw resource type, containing db annotations
 	RegisterRawType(rawResourceType interface{})

--- a/extension/goplugin/schemas.go
+++ b/extension/goplugin/schemas.go
@@ -232,9 +232,8 @@ func (schema *Schema) rawToResource(xRaw reflect.Value) (interface{}, error) {
 	}
 	resource := reflect.New(resourceType).Elem()
 	setValue(resource.FieldByName(xRaw.Type().Name()), xRaw.Addr())
-	setValue(resource.FieldByName("Schema"), reflect.ValueOf(schema))
-	setValue(resource.FieldByName("Logger"), reflect.ValueOf(NewLogger(schema.env)))
-	setValue(resource.FieldByName("Environment"), reflect.ValueOf(schema.env))
+	resourceBase := goext.NewResourceBase(schema.env, schema, NewLogger(schema.env))
+	setValue(resource.FieldByName("ResourceBase"), reflect.ValueOf(resourceBase))
 	return resource.Addr().Interface(), nil
 }
 
@@ -482,8 +481,8 @@ func (schema *Schema) RegisterRawType(typeValue interface{}) {
 }
 
 // RegisterType registers a runtime type for a resource
-func (schema *Schema) RegisterType(typeValue interface{}) {
-	schema.env.RegisterType(schema.raw.ID, typeValue)
+func (schema *Schema) RegisterType(resourceType goext.IResourceBase) {
+	schema.env.RegisterType(schema.raw.ID, resourceType)
 }
 
 func (schema *Schema) RawSchema() interface{} {


### PR DESCRIPTION
This change ensures (during compilation) that RegisterType receives an object of type ResourceBase