### PR TITLE
Fixed setting mock modules

### DIFF
--- a/extension/goplugin/environment_mock.go
+++ b/extension/goplugin/environment_mock.go
@@ -41,62 +41,57 @@ type MockIEnvironment struct {
 	util     goext.IUtil
 }
 
+func (mockEnv *MockIEnvironment) setModules() {
+	mockEnv.mockModules = goext.MockModules{}
+	mockEnv.core = mockEnv.env.Core()
+	mockEnv.logger = mockEnv.env.Logger()
+	mockEnv.schemas = mockEnv.env.Schemas()
+	mockEnv.sync = mockEnv.env.Sync()
+	mockEnv.database = mockEnv.env.Database()
+	mockEnv.http = mockEnv.env.HTTP()
+	mockEnv.auth = mockEnv.env.Auth()
+	mockEnv.config = mockEnv.env.Config()
+	mockEnv.util = mockEnv.env.Util()
+}
+
 func (mockEnv *MockIEnvironment) SetMockModules(modules goext.MockModules) {
 	mockEnv.mockModules = modules
 	ctrl := NewController(mockEnv.testReporter)
 
 	if mockEnv.mockModules.Core {
 		mockEnv.core = goext.NewMockICore(ctrl)
-	} else {
-		mockEnv.core = mockEnv.env.Core()
 	}
 
 	if mockEnv.mockModules.Logger {
 		mockEnv.logger = goext.NewMockILogger(ctrl)
-	} else {
-		mockEnv.logger = mockEnv.env.Logger()
 	}
 
 	if mockEnv.mockModules.Schemas {
 		mockEnv.schemas = goext.NewMockISchemas(ctrl)
-	} else {
-		mockEnv.schemas = mockEnv.env.Schemas()
 	}
 
 	if mockEnv.mockModules.Sync {
 		mockEnv.sync = goext.NewMockISync(ctrl)
-	} else {
-		mockEnv.sync = mockEnv.env.Sync()
 	}
 
 	if mockEnv.mockModules.Database {
 		mockEnv.database = goext.NewMockIDatabase(ctrl)
-	} else {
-		mockEnv.database = mockEnv.env.Database()
 	}
 
 	if mockEnv.mockModules.Http {
 		mockEnv.http = goext.NewMockIHTTP(ctrl)
-	} else {
-		mockEnv.http = mockEnv.env.HTTP()
 	}
 
 	if mockEnv.mockModules.Auth {
 		mockEnv.auth = goext.NewMockIAuth(ctrl)
-	} else {
-		mockEnv.auth = mockEnv.env.Auth()
 	}
 
 	if mockEnv.mockModules.Config {
 		mockEnv.config = goext.NewMockIConfig(ctrl)
-	} else {
-		mockEnv.config = mockEnv.env.Config()
 	}
 
 	if mockEnv.mockModules.Util {
 		mockEnv.util = goext.NewMockIUtil(ctrl)
-	} else {
-		mockEnv.util = mockEnv.env.Util()
 	}
 }
 
@@ -173,7 +168,7 @@ func (mockEnv *MockIEnvironment) MockUtil() *goext.MockIUtil {
 }
 
 func (mockEnv *MockIEnvironment) Reset() {
-	mockEnv.SetMockModules(goext.MockModules{})
+	mockEnv.setModules()
 	mockEnv.env.Reset()
 	mockEnv.env.bindSchemasToEnv(mockEnv)
 }

--- a/extension/goplugin/environment_mock_test.go
+++ b/extension/goplugin/environment_mock_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2017 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goplugin_test
+
+import (
+	"os"
+
+	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/options"
+	"github.com/cloudwan/gohan/extension/goext"
+	"github.com/cloudwan/gohan/extension/goplugin"
+	"github.com/cloudwan/gohan/extension/goplugin/test_data/ext_good/test"
+	"github.com/cloudwan/gohan/schema"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Mocks", func() {
+	var (
+		env        *goplugin.MockIEnvironment
+		dbFile     string
+		testSchema goext.ISchema
+		context    goext.Context
+	)
+
+	const (
+		SchemaPath = "test_data/test_schema.yaml"
+	)
+
+	BeforeEach(func() {
+		var dbType string
+		if os.Getenv("MYSQL_TEST") == "true" {
+			dbFile = "root@/gohan_test"
+			dbType = "mysql"
+		} else {
+			dbFile = "test.db"
+			dbType = "sqlite3"
+		}
+
+		schemaManager := schema.GetManager()
+		Expect(schemaManager.LoadSchemaFromFile(SchemaPath)).To(Succeed())
+		rawDB, err := db.ConnectDB(dbType, dbFile, db.DefaultMaxOpenConn, options.Default())
+		Expect(err).ToNot(HaveOccurred())
+		envReal := goplugin.NewEnvironment("test", nil, nil)
+
+		Expect(envReal.Load("test_data/ext_good/ext_good.so")).To(Succeed())
+		Expect(envReal.Start()).To(Succeed())
+		envReal.SetDatabase(rawDB)
+		env = goplugin.NewMockIEnvironment(envReal, GinkgoT())
+		env.Reset()
+		testSchema = env.Schemas().Find("test")
+		Expect(testSchema).To(Not(BeNil()))
+		Expect(db.InitDBWithSchemas(dbType, dbFile, db.DefaultTestInitDBParams())).To(Succeed())
+		context = goext.MakeContext()
+	})
+
+	AfterEach(func() {
+		env.Reset()
+		os.Remove(dbFile)
+		schema.ClearManager()
+	})
+
+	Context("Mocking module", func() {
+		It("should mock sync module", func() {
+			env.SetMockModules(goext.MockModules{Sync: true})
+			env.MockSync().EXPECT().Fetch("testKey").Return(&goext.Node{Value: "42"}, nil)
+
+			resp, err := env.Sync().Fetch("testKey")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.Value).To(Equal("42"))
+		})
+
+		It("should not affect another module", func() {
+			createdResource := test.Test{
+				ID:          "some-id",
+				Description: "description",
+				TestSuiteID: goext.MakeNullString(),
+				Name:        goext.MakeNullString(),
+			}
+			goext.Within(env, context, func(tx goext.ITransaction) error {
+				Expect(testSchema.CreateRaw(&createdResource, context)).To(Succeed())
+				return nil
+			})
+
+			env.SetMockModules(goext.MockModules{Sync: true})
+
+			goext.Within(env, context, func(tx goext.ITransaction) error {
+				returnedResources, err := testSchema.ListRaw(goext.Filter{}, nil, context)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(returnedResources).To(HaveLen(1))
+				returnedResource := returnedResources[0]
+				Expect(&createdResource).To(Equal(returnedResource))
+				return nil
+			})
+		})
+	})
+})


### PR DESCRIPTION
Currently setting one mock module affects another i.e. after creating an object and setting sync to be mock module all information from DB is gone.