### PR TITLE
[ESI-16183] Goext: preserve DbOptions when cloning the Environment

### DIFF
--- a/extension/goplugin/database.go
+++ b/extension/goplugin/database.go
@@ -49,7 +49,8 @@ func (db *Database) Clone() *Database {
 		return nil
 	}
 	return &Database{
-		raw: db.raw,
+		raw:  db.raw,
+		opts: db.opts,
 	}
 }
 


### PR DESCRIPTION
Without this fix, the Within logic in goexts was not working, because the default values (0/0) were used