### PR TITLE
[ESI-16260] Marshal nil pointer to structs into undefined

### DIFF
--- a/extension/goplugin/integration_tests/end_to_end_test.go
+++ b/extension/goplugin/integration_tests/end_to_end_test.go
@@ -135,8 +135,15 @@ var _ = Describe("Environment", func() {
 				"name":          nil,
 			}
 
+			expectedResponse := map[string]interface{}{
+				"id":            "testId",
+				"description":   "test description",
+				"test_suite_id": nil,
+				"name":          nil,
+			}
+
 			result := testURL("PUT", baseURL+"/v0.1/tests/testId", adminTokenID, resource, http.StatusCreated)
-			Expect(result).To(HaveKeyWithValue("test", util.MatchAsJSON(resource)))
+			Expect(result).To(HaveKeyWithValue("test", expectedResponse))
 		})
 
 		It("Fails to create when string field given as int", func() {

--- a/extension/goplugin/schemas_test.go
+++ b/extension/goplugin/schemas_test.go
@@ -602,8 +602,6 @@ var _ = Describe("Schemas", func() {
 
 			Expect(context).To(HaveKeyWithValue("id", "42"))
 			Expect(context).To(HaveKeyWithValue("description", "test"))
-			Expect(context).To(HaveKey("subobject"))
-			Expect(context["subobject"]).To(BeNil())
 		})
 		It("should convert resource to context with null string defined", func() {
 			resource := &test.Test{
@@ -618,8 +616,6 @@ var _ = Describe("Schemas", func() {
 			Expect(context).To(HaveKeyWithValue("id", "42"))
 			Expect(context).To(HaveKeyWithValue("description", "test"))
 			Expect(context).To(HaveKeyWithValue("name", "testName"))
-			Expect(context).To(HaveKey("subobject"))
-			Expect(context["subobject"]).To(BeNil())
 		})
 		It("should convert resource to context with null string", func() {
 			resource := &test.Test{
@@ -635,8 +631,6 @@ var _ = Describe("Schemas", func() {
 			Expect(context).To(HaveKeyWithValue("description", "test"))
 			Expect(context).To(HaveKey("name"))
 			Expect(context["name"]).To(BeNil())
-			Expect(context).To(HaveKey("subobject"))
-			Expect(context["subobject"]).To(BeNil())
 		})
 		It("should not convert context to resource with int passed as string", func() {
 			context := map[string]interface{}{

--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -290,7 +290,9 @@ func (util *Util) ResourceToMap(resource interface{}) map[string]interface{} {
 			}
 		} else if v.Kind() == reflect.Ptr {
 			if v.IsNil() {
-				fieldsMap[fieldName] = nil
+				if v.Type().Elem().Kind() != reflect.Struct {
+					fieldsMap[fieldName] = nil
+				}
 			} else {
 				rv := util.ResourceToMap(val)
 				fieldsMap[fieldName] = rv


### PR DESCRIPTION
Previous implementation had some API inconsistency. User couldn't use response returned by GET to  POST request, because not required object, appeared as null. Now all nil pointers to structures are translated to undefined values.