### PR TITLE
[ESI-16352] Fixed emitting post-migration event in Go extensions

### DIFF
--- a/cli/migrate.go
+++ b/cli/migrate.go
@@ -264,6 +264,7 @@ func publishEventWithOptions(envName string, modifiedSchemas []string, eventName
 
 		eventContext := map[string]interface{}{}
 		eventContext["schema"] = s
+		eventContext["schema_id"] = s.ID
 		eventContext["sync"] = sync
 		eventContext["db"] = db
 		eventContext["identity_service"] = ident


### PR DESCRIPTION
Go extension event dispatcher requires 'schema_id' field in context,
to properly dispatch event to registered schema.
In case when this field isn't available it dispatches to all registered handlers.

This behaviour isn't expected since we would want to dispatch migration event
to schemas which were marked in migration.