### PR TITLE
[ESI-16260] Support for default values in API

### DIFF
--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -652,6 +652,7 @@ var _ = Describe("Otto extension manager", func() {
 				"providor_networks": map[string]interface{}{},
 				"route_targets":     []interface{}{},
 				"shared":            false,
+				"config":            nil,
 			}
 			network2 = map[string]interface{}{
 				"id":                "test2",
@@ -898,7 +899,7 @@ var _ = Describe("Otto extension manager", func() {
 
 							Expect(env.HandleEvent("test", context)).To(Succeed())
 							Expect(tx.Commit()).To(Succeed())
-							Expect(context).To(HaveKeyWithValue("networks", ConsistOf(util.MatchAsJSON(network1))))
+							Expect(context["networks"]).To(ConsistOf(util.MatchAsJSON(network1)))
 						})
 					})
 
@@ -1183,7 +1184,8 @@ var _ = Describe("Otto extension manager", func() {
 							Expect(env.HandleEvent("test", context)).To(Succeed())
 							Expect(tx.Commit()).To(Succeed())
 							for key, value := range network2 {
-								Expect(context).To(HaveKeyWithValue("network", HaveKeyWithValue(key, value)))
+								Expect(context["network"]).To(HaveKey(key))
+								Expect(context["network"].(map[string]interface{})[key]).To(Equal(value))
 							}
 						})
 					})

--- a/schema/property.go
+++ b/schema/property.go
@@ -57,7 +57,7 @@ func NewProperty(id, title, description, typeID, format, relation, relationColum
 }
 
 //NewPropertyFromObj make Property  from obj
-func NewPropertyFromObj(id string, rawTypeData interface{}, required bool) (*Property, error) {
+func NewPropertyFromObj(id string, rawTypeData interface{}, required bool) *Property {
 	typeData := rawTypeData.(map[string]interface{})
 	title, _ := typeData["title"].(string)
 	description, _ := typeData["description"].(string)
@@ -92,5 +92,5 @@ func NewPropertyFromObj(id string, rawTypeData interface{}, required bool) (*Pro
 	indexed, _ := typeData["indexed"].(bool)
 	Property := NewProperty(id, title, description, typeID, format, relation, relationColumn, relationProperty,
 		sqlType, unique, nullable, cascade, properties, defaultValue, indexed)
-	return &Property, nil
+	return &Property
 }

--- a/schema/property.go
+++ b/schema/property.go
@@ -94,3 +94,25 @@ func NewPropertyFromObj(id string, rawTypeData interface{}, required bool) *Prop
 		sqlType, unique, nullable, cascade, properties, defaultValue, indexed)
 	return &Property
 }
+
+func (p *Property) getDefaultMask() interface{} {
+	if p.Default != nil {
+		return p.Default
+	}
+	if p.Type == "object" {
+		var defaultValue map[string]interface{}
+		for innerPropertyID, innerPropertyValue := range p.Properties {
+			prop := NewPropertyFromObj(innerPropertyID, innerPropertyValue, false)
+			innerDefaultMask := prop.getDefaultMask()
+			if innerDefaultMask != nil {
+				if defaultValue == nil {
+					defaultValue = map[string]interface{}{}
+				}
+				defaultValue[innerPropertyID] = innerDefaultMask
+			}
+		}
+		return defaultValue
+	}
+
+	return nil
+}

--- a/schema/resource.go
+++ b/schema/resource.go
@@ -139,5 +139,6 @@ func (resource *Resource) PopulateDefaults() error {
 			resource.properties[property.ID] = property.Default
 		}
 	}
+
 	return nil
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -254,10 +254,7 @@ func (schema *Schema) Init() error {
 	schema.Properties = []Property{}
 	for id, property := range properties {
 		propertyRequired := util.ContainsString(required, id)
-		propertyObj, err := NewPropertyFromObj(id, property, propertyRequired)
-		if err != nil {
-			return fmt.Errorf("Invalid schema: Properties is missing %v", err)
-		}
+		propertyObj := NewPropertyFromObj(id, property, propertyRequired)
 		schema.Properties = append(schema.Properties, *propertyObj)
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -983,6 +983,16 @@ func getNetwork(color string, tenant string) map[string]interface{} {
 		"route_targets":     []string{"1000:10000", "2000:20000"},
 		"shared":            false,
 		"providor_networks": map[string]interface{}{"segmentation_id": 12, "segmentation_type": "vlan"},
+		"config": map[string]interface{}{
+			"default_vlan": map[string]interface{}{
+				"vlan_id": float64(1),
+				"name":    "default_vlan",
+			},
+			"empty_vlan": map[string]interface{}{},
+			"vpn_vlan": map[string]interface{}{
+				"name": "vpn_vlan",
+			},
+		},
 	}
 }
 

--- a/tests/test_schema.json
+++ b/tests/test_schema.json
@@ -143,6 +143,87 @@
                         "type": "array",
                         "unique": false
                     },
+                    "config": {
+                        "description": "Config",
+                        "title": "Config",
+                        "type": "object",
+                        "properties": {
+                            "default_vlan": {
+                                "description": "Default VLAN",
+                                "title": "Default VLAN",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "default": "default_vlan",
+                                        "title": "Name",
+                                        "description": "Name"
+                                    },
+                                    "vlan_id": {
+                                        "type": "integer",
+                                        "default": 1,
+                                        "title": "VlanID",
+                                        "description": "Vlan ID"
+                                    }
+                                }
+                            },
+                            "vpn_vlan": {
+                                "description": "VPN VLAN",
+                                "title": "VPN VLAN",
+                                "type": "object",
+                                "default": {
+                                    "name": "vpn_vlan"
+                                },
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "Name",
+                                        "description": "Name"
+                                    },
+                                    "vlan_id": {
+                                        "type": "integer",
+                                        "title": "VlanID",
+                                        "description": "Vlan ID"
+                                    }
+                                }
+                            },
+                            "user_vlan": {
+                                "description": "User VLAN",
+                                "title": "User VLAN",
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "Name",
+                                        "description": "Name"
+                                    },
+                                    "vlan_id": {
+                                        "type": "integer",
+                                        "title": "VlanID",
+                                        "description": "Vlan ID"
+                                    }
+                                }
+                            },
+                            "empty_vlan": {
+                                "description": "Empty VLAN",
+                                "title": "Empty VLAN",
+                                "type": "object",
+                                "default": {},
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "title": "Name",
+                                        "description": "Name"
+                                    },
+                                    "vlan_id": {
+                                        "type": "integer",
+                                        "title": "VlanID",
+                                        "description": "Vlan ID"
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "tenant_id": {
                         "permission": [
                             "create"
@@ -159,6 +240,7 @@
                     "name",
                     "providor_networks",
                     "route_targets",
+                    "config",
                     "tenant_id"
                 ],
                 "type": "object"

--- a/tests/test_schema.yaml
+++ b/tests/test_schema.yaml
@@ -238,10 +238,76 @@ schemas:
         type: boolean
         unique: false
         default: false
+      config:
+        permission:
+          - create
+          - update
+        description: Config
+        title: Config
+        type: object
+        properties:
+          default_vlan:
+            description: Default VLAN
+            title: Default VLAN
+            type: object
+            properties:
+              name:
+                type: string
+                default: "default_vlan"
+                title: Name
+                description: Name
+              vlan_id:
+                type: integer
+                default: 1
+                title: VlanID
+                description: Vlan ID
+          vpn_vlan:
+            description: VPN VLAN
+            title: VPN VLAN
+            type: object
+            default:
+              name: "vpn_vlan"
+            properties:
+              name:
+                type: string
+                title: Name
+                description: Name
+              vlan_id:
+                type: integer
+                title: VlanID
+                description: Vlan ID
+          user_vlan:
+            description: User VLAN
+            title: User VLAN
+            type: object
+            properties:
+              name:
+                type: string
+                title: Name
+                description: Name
+              vlan_id:
+                type: integer
+                title: VlanID
+                description: Vlan ID
+          empty_vlan:
+            description: Empty VLAN
+            title: Empty VLAN
+            type: object
+            default: {}
+            properties:
+              name:
+                type: string
+                title: Name
+                description: Name
+              vlan_id:
+                type: integer
+                title: VlanID
+                description: Vlan ID
     propertiesOrder:
     - providor_networks
     - route_targets
     - shared
+    - config
     type: object
   singular: network
   title: Network


### PR DESCRIPTION
Currently default values defined in schema were filled only for 1st level depth properties. This commit introduces recursive logic which fills defaults on all levels.
