### PR TITLE
[BL-33] Added Context interface in Go extensions

### DIFF
--- a/extension/goext/context.go
+++ b/extension/goext/context.go
@@ -48,10 +48,36 @@ type Context interface {
 	SetInput(input map[string]interface{}) Context
 	GetInput() (map[string]interface{}, bool)
 
+	GetAuth() (interface{}, bool)
+	SetAuth(auth interface{}) Context
+
+	GetRole() (interface{}, bool)
+	SetRole(role interface{}) Context
+
 	Clone() Context
 }
 
 type GohanContext map[string]interface{}
+
+func (c GohanContext) GetAuth() (interface{}, bool) {
+	auth, ok := c["auth"]
+	return auth, ok
+}
+
+func (c GohanContext) SetAuth(auth interface{}) Context {
+	c["auth"] = auth
+	return c
+}
+
+func (c GohanContext) GetRole() (interface{}, bool) {
+	role, ok := c["role"]
+	return role, ok
+}
+
+func (c GohanContext) SetRole(role interface{}) Context {
+	c["role"] = role
+	return c
+}
 
 func (c GohanContext) SetInput(input map[string]interface{}) Context {
 	c["input"] = input

--- a/extension/goext/context.go
+++ b/extension/goext/context.go
@@ -1,0 +1,258 @@
+package goext
+
+import (
+	"context"
+	"net/http"
+)
+
+// Context represents a context of a handler
+type Context interface {
+	GetID() (string, bool)
+	SetID(id string) Context
+
+	GetSchema() (ISchema, bool)
+	SetSchema(schema ISchema) Context
+
+	GetSchemaID() (string, bool)
+	SetSchemaID(schemaID string) Context
+
+	SetISchema(schema ISchema) Context
+	GetISchema() (ISchema, bool)
+	DeleteISchema()
+
+	GetResource() (Resource, bool)
+	SetResource(resource Resource) Context
+	DeleteResource()
+
+	SetTransaction(tx ITransaction) Context
+	GetTransaction() (ITransaction, bool)
+	DeleteTransaction()
+
+	SetContext(context context.Context) Context
+	GetContext() (context.Context, bool)
+	DeleteContext()
+
+	GetIsTopLevelHandler() (bool, bool)
+	SetTopLevelHandler(isTopLevelHandler bool) Context
+	DeleteIsTopLevelHandler()
+
+	GetHttpRequest() (*http.Request, bool)
+	SetHttpRequest(req *http.Request) Context
+
+	GetTenantID() (string, bool)
+	SetTenantID(tenantID string) Context
+
+	GetResponse() (interface{}, bool)
+	SetResponse(response interface{}) Context
+
+	SetInput(input map[string]interface{}) Context
+	GetInput() (map[string]interface{}, bool)
+
+	Clone() Context
+}
+
+type GohanContext map[string]interface{}
+
+func (c GohanContext) SetInput(input map[string]interface{}) Context {
+	c["input"] = input
+	return c
+}
+
+func (c GohanContext) GetInput() (map[string]interface{}, bool) {
+	input, ok := c["input"]
+	if !ok {
+		return nil, ok
+	}
+	return input.(map[string]interface{}), ok
+}
+
+func (c GohanContext) GetID() (string, bool) {
+	id, ok := c["id"]
+	if !ok {
+		return "", ok
+	}
+	return id.(string), ok
+}
+
+func (c GohanContext) SetID(id string) Context {
+	c["id"] = id
+	return c
+}
+
+func (c GohanContext) GetResponse() (interface{}, bool) {
+	response, ok := c["response"]
+	if !ok {
+		return nil, ok
+	}
+	return response, ok
+}
+
+func (c GohanContext) SetResponse(response interface{}) Context {
+	c["response"] = response
+	return c
+}
+
+func (c GohanContext) GetTenantID() (string, bool) {
+	tenantID, ok := c["tenant_id"]
+	if !ok {
+		return "", ok
+	}
+	return tenantID.(string), ok
+}
+
+func (c GohanContext) SetTenantID(tenantID string) Context {
+	c["tenant_id"] = tenantID
+	return c
+}
+
+func (c GohanContext) SetISchema(schema ISchema) Context {
+	c["schema"] = schema
+	return c
+}
+
+func (c GohanContext) GetISchema() (ISchema, bool) {
+	schema, ok := c["schema"]
+	if !ok {
+		return nil, ok
+	}
+	return schema.(ISchema), ok
+}
+
+func (c GohanContext) DeleteISchema() {
+	delete(c, "schema")
+}
+
+func (c GohanContext) Clone() Context {
+	contextCopy := GohanContext{}
+	for k, v := range c {
+		contextCopy[k] = v
+	}
+	return contextCopy
+}
+
+func (c GohanContext) DeleteResource() {
+	delete(c, "resource")
+}
+
+func (c GohanContext) DeleteTransaction() {
+	delete(c, "transaction")
+}
+
+func (c GohanContext) DeleteContext() {
+	delete(c, "context")
+}
+
+func (c GohanContext) GetIsTopLevelHandler() (bool, bool) {
+	isTopLevelHandler, ok := c[KeyTopLevelHandler]
+	if !ok {
+		return false, ok
+	}
+	return isTopLevelHandler.(bool), ok
+}
+
+func (c GohanContext) SetTopLevelHandler(isTopLevelHandler bool) Context {
+	c[KeyTopLevelHandler] = isTopLevelHandler
+	return c
+}
+
+func (c GohanContext) DeleteIsTopLevelHandler() {
+	delete(c, KeyTopLevelHandler)
+}
+
+func (c GohanContext) GetHttpRequest() (*http.Request, bool) {
+	httpReq, ok := c["http_request"]
+	if !ok {
+		return nil, ok
+	}
+	if httpReq != nil {
+		return httpReq.(*http.Request), ok
+	}
+	return nil, ok
+}
+
+func (c GohanContext) SetHttpRequest(req *http.Request) Context {
+	c["http_request"] = req
+	return c
+}
+
+func (c GohanContext) IsTopLevelHandler() bool {
+	_, isTopLevelHandler := c[KeyTopLevelHandler]
+	return isTopLevelHandler
+}
+
+func (c GohanContext) GetSchemaID() (string, bool) {
+	schemaID, ok := c["schema_id"]
+	if !ok {
+		return "", ok
+	}
+	return schemaID.(string), ok
+}
+
+func (c GohanContext) SetSchemaID(schemaID string) Context {
+	c["schema_id"] = schemaID
+	return c
+}
+
+func (c GohanContext) GetSchema() (ISchema, bool) {
+	schema, ok := c["schema"]
+	if !ok {
+		return nil, ok
+	}
+	return schema.(ISchema), ok
+}
+
+func (c GohanContext) SetSchema(schema ISchema) Context {
+	c["schema"] = schema
+	return c
+}
+
+func (c GohanContext) GetResource() (Resource, bool) {
+	resource, ok := c["resource"]
+	if !ok {
+		return nil, ok
+	}
+	return resource, ok
+}
+
+func (c GohanContext) SetResource(resource Resource) Context {
+	c["resource"] = resource
+	return c
+}
+
+func (c GohanContext) SetTransaction(tx ITransaction) Context {
+	c["transaction"] = tx
+	return c
+}
+
+func (c GohanContext) GetTransaction() (ITransaction, bool) {
+	tx, ok := c["transaction"]
+	if !ok {
+		return nil, ok
+	}
+	return tx.(ITransaction), ok
+}
+
+func (c GohanContext) SetContext(context context.Context) Context {
+	c["context"] = context
+	return c
+}
+
+func (c GohanContext) GetContext() (context.Context, bool) {
+	ctx, ok := c["context"]
+	if !ok {
+		return nil, ok
+	}
+	return ctx.(context.Context), ok
+}
+
+func MakeContext() Context {
+	return GohanContext{}
+}
+
+func GetContext(requestContext Context) context.Context {
+	ctx, ok := requestContext.GetContext()
+	if ok {
+		return ctx
+	}
+	return context.Background()
+}

--- a/extension/goext/context.go
+++ b/extension/goext/context.go
@@ -10,9 +10,6 @@ type Context interface {
 	GetID() (string, bool)
 	SetID(id string) Context
 
-	GetSchema() (ISchema, bool)
-	SetSchema(schema ISchema) Context
-
 	GetSchemaID() (string, bool)
 	SetSchemaID(schemaID string) Context
 
@@ -89,7 +86,11 @@ func (c GohanContext) GetInput() (map[string]interface{}, bool) {
 	if !ok {
 		return nil, ok
 	}
-	return input.(map[string]interface{}), ok
+	if input != nil {
+		return input.(map[string]interface{}), ok
+	}
+
+	return nil, ok
 }
 
 func (c GohanContext) GetID() (string, bool) {
@@ -141,7 +142,11 @@ func (c GohanContext) GetISchema() (ISchema, bool) {
 	if !ok {
 		return nil, ok
 	}
-	return schema.(ISchema), ok
+	if schema != nil {
+		return schema.(ISchema), ok
+	}
+
+	return nil, ok
 }
 
 func (c GohanContext) DeleteISchema() {
@@ -219,19 +224,6 @@ func (c GohanContext) SetSchemaID(schemaID string) Context {
 	return c
 }
 
-func (c GohanContext) GetSchema() (ISchema, bool) {
-	schema, ok := c["schema"]
-	if !ok {
-		return nil, ok
-	}
-	return schema.(ISchema), ok
-}
-
-func (c GohanContext) SetSchema(schema ISchema) Context {
-	c["schema"] = schema
-	return c
-}
-
 func (c GohanContext) GetResource() (Resource, bool) {
 	resource, ok := c["resource"]
 	if !ok {
@@ -255,7 +247,11 @@ func (c GohanContext) GetTransaction() (ITransaction, bool) {
 	if !ok {
 		return nil, ok
 	}
-	return tx.(ITransaction), ok
+	if tx != nil {
+		return tx.(ITransaction), ok
+	}
+
+	return nil, ok
 }
 
 func (c GohanContext) SetContext(context context.Context) Context {
@@ -268,7 +264,10 @@ func (c GohanContext) GetContext() (context.Context, bool) {
 	if !ok {
 		return nil, ok
 	}
-	return ctx.(context.Context), ok
+	if ctx != nil {
+		return ctx.(context.Context), ok
+	}
+	return nil, ok
 }
 
 func MakeContext() Context {

--- a/extension/goext/database.go
+++ b/extension/goext/database.go
@@ -82,7 +82,7 @@ func withinDetached(db IDatabase, context Context, txBegin func() (ITransaction,
 			return err
 		}
 
-		context["transaction"] = tx
+		context.SetTransaction(tx)
 
 		err = fn(tx)
 
@@ -90,7 +90,7 @@ func withinDetached(db IDatabase, context Context, txBegin func() (ITransaction,
 			err = tx.Commit()
 
 			if err == nil {
-				delete(context, "transaction")
+				context.DeleteTransaction()
 				return nil
 			}
 		} else if !tx.Closed() {
@@ -100,12 +100,12 @@ func withinDetached(db IDatabase, context Context, txBegin func() (ITransaction,
 			}
 		}
 
-		delete(context, "transaction")
+		context.DeleteTransaction()
 
 		log.Debug("scoped database transaction failed with error: %s", err)
 
 		if !IsDeadlock(err) {
-			delete(context, "transaction")
+			context.DeleteTransaction()
 			return err
 		}
 

--- a/extension/goext/schemas.go
+++ b/extension/goext/schemas.go
@@ -16,8 +16,8 @@
 package goext
 
 import (
-	"context"
 	"errors"
+	"reflect"
 )
 
 // LockPolicy indicates lock policy
@@ -40,9 +40,6 @@ type Resource interface{}
 // Resources is a list of resources
 type Resources []Resource
 
-// Context represents a context of a handler
-type Context map[string]interface{}
-
 // Filter represents filtering options for fetching functions
 type Filter map[string]interface{}
 
@@ -52,58 +49,6 @@ type Paginator struct {
 	Order  string
 	Limit  uint64
 	Offset uint64
-}
-
-// MakeContext creates an empty context
-func MakeContext() Context {
-	return make(map[string]interface{})
-}
-
-// WithSchemaID appends schema ID to given context
-func (ctx Context) WithSchemaID(schemaID string) Context {
-	ctx["schema_id"] = schemaID
-	return ctx
-}
-
-// WithISchema appends ISchema to given context
-func (ctx Context) WithISchema(schema ISchema) Context {
-	ctx["schema"] = schema
-	return ctx
-}
-
-// WithResource appends resource to given context
-func (ctx Context) WithResource(resource Resource) Context {
-	ctx["resource"] = resource
-	return ctx
-}
-
-// WithResourceID appends resource ID to given context
-func (ctx Context) WithResourceID(resourceID string) Context {
-	ctx["id"] = resourceID
-	return ctx
-}
-
-// WithTransaction appends transaction to given context
-func (ctx Context) WithTransaction(tx ITransaction) Context {
-	ctx["transaction"] = tx
-	return ctx
-}
-
-// Clone returns copy of context
-func (ctx Context) Clone() Context {
-	contextCopy := MakeContext()
-	for k, v := range ctx {
-		contextCopy[k] = v
-	}
-	return contextCopy
-}
-
-func GetContext(requestContext Context) context.Context {
-	if rawCtx, hasCtx := requestContext["context"]; hasCtx {
-		return rawCtx.(context.Context)
-	} else {
-		return context.Background()
-	}
 }
 
 // PriorityDefault is a default handler priority
@@ -179,6 +124,9 @@ type ISchema interface {
 	// Deprecated: use RegisterTypes instead
 	RegisterType(resourceType IResourceBase)
 
+	// GetType returns type registered by RegisterType
+	GetType() reflect.Type
+
 	// RegisterRawType registers a raw resource type, containing db annotations
 	//
 	// Deprecated: use RegisterTypes instead
@@ -186,6 +134,9 @@ type ISchema interface {
 
 	// RegisterTypes registers both resource types derived from IResourceBase and raw containing db annotations
 	RegisterTypes(rawResourceType interface{}, resourceType IResourceBase)
+
+	// GetRawType returns type registered by RegisterRawType
+	GetRawType() reflect.Type
 
 	// ResourceFromMap converts mapped representation to structure representation of the raw resource registered for schema
 	ResourceFromMap(context map[string]interface{}) (Resource, error)

--- a/extension/goplugin/auth.go
+++ b/extension/goplugin/auth.go
@@ -24,7 +24,7 @@ import (
 type Auth struct{}
 
 func (a *Auth) HasRole(context goext.Context, principal string) bool {
-	roleRaw, ok := context.(goext.GohanContext)["role"]
+	roleRaw, ok := context.GetRole()
 	if !ok {
 		log.Warning("HasRole: missing 'role' field in context")
 		return false
@@ -40,7 +40,7 @@ func (a *Auth) HasRole(context goext.Context, principal string) bool {
 }
 
 func (a *Auth) GetTenantName(context goext.Context) string {
-	authRaw, ok := context.(goext.GohanContext)["auth"]
+	authRaw, ok := context.GetAuth()
 	if !ok {
 		log.Warning("GetTenantName: missing 'auth' field in context")
 		return ""

--- a/extension/goplugin/auth.go
+++ b/extension/goplugin/auth.go
@@ -24,7 +24,7 @@ import (
 type Auth struct{}
 
 func (a *Auth) HasRole(context goext.Context, principal string) bool {
-	roleRaw, ok := context["role"]
+	roleRaw, ok := context.(goext.GohanContext)["role"]
 	if !ok {
 		log.Warning("HasRole: missing 'role' field in context")
 		return false
@@ -40,7 +40,7 @@ func (a *Auth) HasRole(context goext.Context, principal string) bool {
 }
 
 func (a *Auth) GetTenantName(context goext.Context) string {
-	authRaw, ok := context["auth"]
+	authRaw, ok := context.(goext.GohanContext)["auth"]
 	if !ok {
 		log.Warning("GetTenantName: missing 'auth' field in context")
 		return ""

--- a/extension/goplugin/auth_test.go
+++ b/extension/goplugin/auth_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Auth", func() {
 		policy, role := manager.PolicyValidate("create", "/v2.0/networks", auth)
 		Expect(policy).NotTo(BeNil())
 
-		context := goext.MakeContext()
+		context := goext.MakeContext().(goext.GohanContext)
 		context["policy"] = policy
 		context["role"] = role
 		context["tenant_id"] = auth.TenantID()

--- a/extension/goplugin/core.go
+++ b/extension/goplugin/core.go
@@ -45,7 +45,10 @@ func (core *Core) TriggerEvent(event string, context goext.Context) error {
 		log.Panic("schema_id not found in context")
 	}
 
-	contextMap := context.(goext.GohanContext)
+	contextMap, ok := context.(goext.GohanContext)
+	if !ok {
+		log.Panic("context passed to TriggerEvent should be of goext.GohanContext type")
+	}
 
 	// JS extensions expect context["schema"] to be a *schema.Schema.
 	// If a schema is already set, we should overwrite it with proper type and

--- a/extension/goplugin/core_test.go
+++ b/extension/goplugin/core_test.go
@@ -16,6 +16,7 @@
 package goplugin_test
 
 import (
+	"github.com/cloudwan/gohan/extension/goext"
 	"github.com/cloudwan/gohan/extension/goplugin"
 	"github.com/cloudwan/gohan/schema"
 	. "github.com/onsi/ginkgo"
@@ -51,12 +52,12 @@ var _ = Describe("Core", func() {
 
 	Context("Triggering an event", func() {
 		It("should panic when schema_id not specified", func() {
-			ctx := map[string]interface{}{}
+			ctx := goext.GohanContext{}
 			Expect(func() { env.Core().TriggerEvent("dummyEventName", ctx) }).To(Panic())
 		})
 
 		It("should restore original schema when already specified", func() {
-			ctx := map[string]interface{}{
+			ctx := goext.GohanContext{
 				"schema":    "testSchema",
 				"schema_id": "test",
 			}
@@ -66,7 +67,7 @@ var _ = Describe("Core", func() {
 		})
 
 		It("should clean schema field when none specified", func() {
-			ctx := map[string]interface{}{
+			ctx := goext.GohanContext{
 				"schema_id": "test",
 			}
 

--- a/extension/goplugin/environment.go
+++ b/extension/goplugin/environment.go
@@ -451,6 +451,9 @@ func handleEventForEnv(env IEnvironment, event string, requestContext goext.Goha
 		if rawTx, isRawTx := tx.(transaction.Transaction); isRawTx {
 			var itx goext.ITransaction = &Transaction{tx: rawTx}
 			requestContext["transaction"] = itx
+			defer func() {
+				requestContext["transaction"] = rawTx
+			}()
 		}
 	}
 

--- a/extension/goplugin/environment.go
+++ b/extension/goplugin/environment.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	gohan_db "github.com/cloudwan/gohan/db"
-	"github.com/cloudwan/gohan/db/sql"
+	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension"
 	"github.com/cloudwan/gohan/extension/goext"
 	gohan_logger "github.com/cloudwan/gohan/log"
@@ -448,7 +448,7 @@ func handleEventForEnv(env IEnvironment, event string, requestContext goext.Goha
 	// Events sent via TriggerEvent has raw transaction in context. It's only needed in JS extensions,
 	// Go plugins does not has this requirement, so wrap it with better interface.
 	if tx, hasTx := requestContext["transaction"]; hasTx {
-		if rawTx, isRawTx := tx.(*sql.Transaction); isRawTx {
+		if rawTx, isRawTx := tx.(transaction.Transaction); isRawTx {
 			var itx goext.ITransaction = &Transaction{tx: rawTx}
 			requestContext["transaction"] = itx
 		}

--- a/extension/goplugin/environment_mock.go
+++ b/extension/goplugin/environment_mock.go
@@ -233,6 +233,14 @@ func (mockEnv *MockIEnvironment) LoadExtensionsForPath(extensions []*schema.Exte
 	return mockEnv.env.LoadExtensionsForPath(extensions, timeLimit, timeLimits, path)
 }
 
+func (mockEnv *MockIEnvironment) GetRawType(name string) reflect.Type {
+	return mockEnv.env.GetRawType(name)
+}
+
+func (mockEnv *MockIEnvironment) GetType(name string) reflect.Type {
+	return mockEnv.env.GetType(name)
+}
+
 func NewMockIEnvironment(env *Environment, testReporter gomock.TestReporter) *MockIEnvironment {
 	mockIEnvironment := &MockIEnvironment{env: env, testReporter: testReporter}
 	return mockIEnvironment

--- a/extension/goplugin/js_integration_test.go
+++ b/extension/goplugin/js_integration_test.go
@@ -106,7 +106,7 @@ var _ = Describe("JS integration", func() {
 		)
 
 		BeforeEach(func() {
-			ctx = map[string]interface{}{
+			ctx = goext.GohanContext{
 				"schema_id": "test",
 			}
 

--- a/extension/goplugin/schemas_test.go
+++ b/extension/goplugin/schemas_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Schemas", func() {
 			tx, err = env.Database().Begin()
 			Expect(err).To(BeNil())
 
-			context = goext.MakeContext().WithTransaction(tx)
+			context = goext.MakeContext().SetTransaction(tx)
 
 			createdResource = test.Test{
 				ID:          "some-id",
@@ -510,7 +510,7 @@ var _ = Describe("Schemas", func() {
 			Expect(err).To(BeNil())
 			defer firstTx.Close()
 
-			context := goext.MakeContext().WithTransaction(firstTx)
+			context := goext.MakeContext().SetTransaction(firstTx)
 			_, err = testSchema.LockFetchRaw(createdResource.ID, context, goext.SkipRelatedResources)
 			Expect(err).To(Succeed())
 
@@ -526,7 +526,7 @@ var _ = Describe("Schemas", func() {
 				Expect(err).To(Succeed())
 				defer secondTx.Close()
 
-				context := goext.MakeContext().WithTransaction(secondTx)
+				context := goext.MakeContext().SetTransaction(secondTx)
 				wg.Done()
 				_, err = testSchema.LockFetchRaw(createdResource.ID, context, goext.SkipRelatedResources)
 				Expect(err).To(Succeed())
@@ -550,7 +550,7 @@ var _ = Describe("Schemas", func() {
 			Expect(err).To(BeNil())
 			defer firstTx.Close()
 
-			context := goext.MakeContext().WithTransaction(firstTx)
+			context := goext.MakeContext().SetTransaction(firstTx)
 			_, err = testSchema.LockListRaw(map[string]interface{}{"id": createdResource.ID}, nil, context, goext.SkipRelatedResources)
 			Expect(err).To(Succeed())
 
@@ -566,7 +566,7 @@ var _ = Describe("Schemas", func() {
 				Expect(err).To(Succeed())
 				defer secondTx.Close()
 
-				context := goext.MakeContext().WithTransaction(secondTx)
+				context := goext.MakeContext().SetTransaction(secondTx)
 				wg.Done()
 				_, err = testSchema.LockListRaw(map[string]interface{}{"id": createdResource.ID}, nil, context, goext.SkipRelatedResources)
 				Expect(err).To(Succeed())
@@ -764,7 +764,7 @@ var _ = Describe("Schemas", func() {
 
 	Context("Context passed to handlers should be copied from original", func() {
 		var (
-			context      goext.Context
+			context      goext.GohanContext
 			tx           goext.ITransaction
 			testResource *test.Test
 		)
@@ -773,7 +773,7 @@ var _ = Describe("Schemas", func() {
 			var err error
 			tx, err = env.Database().Begin()
 			Expect(err).ToNot(HaveOccurred())
-			context = goext.MakeContext().WithTransaction(tx)
+			context = goext.MakeContext().SetTransaction(tx).(goext.GohanContext)
 			context["test"] = 42
 			testResource = &test.Test{ID: "13", Name: goext.MakeString("123"), TestSuiteID: goext.MakeNullString()}
 

--- a/extension/goplugin/test_data/ext_good/ext_good.go
+++ b/extension/goplugin/test_data/ext_good/ext_good.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"context"
 	"time"
 
 	"github.com/cloudwan/gohan/extension/goext"
@@ -52,7 +51,7 @@ func Init(env goext.IEnvironment) error {
 }
 
 func handleWaitForContextCancel(requestContext goext.Context, _ goext.IEnvironment) *goext.Error {
-	ctx := requestContext["context"].(context.Context)
+	ctx, _ := requestContext.GetContext()
 
 	select {
 	case <-ctx.Done():
@@ -66,18 +65,19 @@ func handleWaitForContextCancel(requestContext goext.Context, _ goext.IEnvironme
 
 func handleEcho(requestContext goext.Context, env goext.IEnvironment) *goext.Error {
 	env.Logger().Debug("Handling echo")
-	requestContext["response"] = requestContext["input"]
+	typedContext := requestContext.(goext.GohanContext)
+	typedContext["response"] = typedContext["input"]
 	return nil
 }
 
 func handleInvokeJs(requestContext goext.Context, env goext.IEnvironment) *goext.Error {
 	env.Logger().Debug("Handling invoke JS")
 
-	ctx := requestContext.Clone()
-	ctx["schema_id"] = "test"
+	ctx := requestContext.Clone().(goext.GohanContext)
+	ctx.SetSchemaID("test")
 	env.Core().TriggerEvent("js_listener", ctx)
 
-	requestContext["response"] = ctx["js_result"]
+	requestContext.SetResponse(ctx["js_result"])
 	return nil
 }
 

--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -32,8 +32,8 @@ type Util struct {
 }
 
 func contextGetTransaction(ctx goext.Context) (goext.ITransaction, bool) {
-	ctxTx := ctx["transaction"]
-	if ctxTx == nil {
+	ctxTx, ok := ctx.GetTransaction()
+	if !ok && ctxTx == nil {
 		return nil, false
 	}
 
@@ -74,6 +74,9 @@ func Finish(testReporter gomock.TestReporter) {
 
 // ResourceFromMapForType converts mapped representation to structure representation of the resource for given type
 func (util *Util) ResourceFromMapForType(context map[string]interface{}, rawResource interface{}) (goext.Resource, error) {
+	if context == nil {
+		return nil, nil
+	}
 	resource := reflect.New(reflect.TypeOf(rawResource))
 	if err := resourceFromMap(context, resource); err != nil {
 		return nil, err
@@ -261,6 +264,10 @@ func sliceToMap(context map[string]interface{}, fieldName string, field reflect.
 // ResourceToMap converts structure representation of the resource to mapped representation
 func (util *Util) ResourceToMap(resource interface{}) map[string]interface{} {
 	fieldsMap := map[string]interface{}{}
+
+	if reflect.ValueOf(resource).IsNil() {
+		return nil
+	}
 
 	mapper := reflectx.NewMapper("json")
 	structMap := mapper.TypeMap(reflect.TypeOf(resource))

--- a/extension/goplugin/util_test.go
+++ b/extension/goplugin/util_test.go
@@ -37,6 +37,22 @@ var _ = Describe("Util tests", func() {
 
 	Describe("Marshalling", func() {
 
+		Context("Nil pointer", func() {
+
+			type TestStruct struct {
+			}
+
+			It("To structure results in nil map", func() {
+				var s *TestStruct
+				Expect(env.Util().ResourceToMap(s)).To(BeNil())
+			})
+
+			It("To map results in nil pointer to structure", func() {
+				var m map[string]interface{}
+				Expect(env.Util().ResourceFromMapForType(m, TestStruct{})).To(BeNil())
+			})
+		})
+
 		Context("Custom Maybe structure", func() {
 			type TestResource struct {
 				goext.Maybe


### PR DESCRIPTION
Introduced interface for goext.Context which represent contract between Go extension and Gohan Core. 

Such interface is needed to support typed contexts inside Go extension. 

This PR contain also some tweaks which were needed to support typed contexts:
- Supporting nil pointers to structures, and nil maps during (un)marshalling
- Transaction type available in context is always goplugin.Transaction.