### PR TITLE
Add cached sql transactions

### DIFF
--- a/db/sql/cached_transaction.go
+++ b/db/sql/cached_transaction.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2018 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudwan/gohan/db/pagination"
+	"github.com/cloudwan/gohan/db/transaction"
+	"github.com/cloudwan/gohan/schema"
+	// Import mysql lib
+	_ "github.com/go-sql-driver/mysql"
+	// Import go-sqlite3 lib
+	_ "github.com/mattn/go-sqlite3"
+	// Import go-fakedb lib
+	"github.com/cloudwan/gohan/metrics"
+	"github.com/mitchellh/hashstructure"
+	_ "github.com/nati/go-fakedb"
+)
+
+type CachedState struct {
+	list     []*schema.Resource
+	total    uint64
+	isLocked bool
+}
+
+type CachedTransaction struct {
+	TxInterface
+	QueryCache map[string]CachedState
+}
+
+func MakeCachedTransaction(transx TxInterface) TxInterface {
+	cachedTransaction := &CachedTransaction{transx, nil}
+	cachedTransaction.ClearCache()
+	return cachedTransaction
+}
+
+func (tx *CachedTransaction) Create(resource *schema.Resource) error {
+	return tx.CreateContext(context.Background(), resource)
+}
+
+func (tx *CachedTransaction) CreateContext(ctx context.Context, resource *schema.Resource) error {
+	tx.ClearCache()
+	return tx.TxInterface.CreateContext(ctx, resource)
+}
+
+func (tx *CachedTransaction) Update(resource *schema.Resource) error {
+	return tx.UpdateContext(context.Background(), resource)
+}
+
+func (tx *CachedTransaction) UpdateContext(ctx context.Context, resource *schema.Resource) error {
+	tx.ClearCache()
+	return tx.TxInterface.UpdateContext(context.Background(), resource)
+}
+
+func (tx *CachedTransaction) StateUpdate(resource *schema.Resource, state *transaction.ResourceState) error {
+	return tx.StateUpdateContext(context.Background(), resource, state)
+}
+
+func (tx *CachedTransaction) StateUpdateContext(ctx context.Context, resource *schema.Resource, state *transaction.ResourceState) error {
+	tx.ClearCache()
+	return tx.TxInterface.StateUpdateContext(context.Background(), resource, state)
+}
+
+func (tx *CachedTransaction) Delete(s *schema.Schema, resourceID interface{}) error {
+	return tx.DeleteContext(context.Background(), s, resourceID)
+}
+
+func (tx *CachedTransaction) DeleteContext(ctx context.Context, s *schema.Schema, resourceID interface{}) error {
+	tx.ClearCache()
+	return tx.TxInterface.DeleteContext(context.Background(), s, resourceID)
+}
+
+func (tx *CachedTransaction) List(s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator) (list []*schema.Resource, total uint64, err error) {
+	return tx.ListContext(context.Background(), s, filter, options, pg)
+}
+
+//List resources in the db
+func (tx *CachedTransaction) ListContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator) (list []*schema.Resource, total uint64, err error) {
+	sc := listContextHelper(s, filter, options, pg)
+
+	list, total, wasCached, _, err := tx.getCached(s.ID, sc)
+
+	if err != nil {
+		return
+	}
+
+	if !wasCached {
+		metrics.UpdateCounter(1, "tx.%s.cache.miss", s.ID)
+		list, total, err = tx.TxInterface.ListContext(ctx, s, filter, options, pg)
+		tx.saveCache(s.ID, sc, list, total, false, err)
+	} else {
+		metrics.UpdateCounter(1, "tx.%s.cache.hit", s.ID)
+	}
+	return
+}
+
+func (tx *CachedTransaction) createKey(schemaID string, sc *selectContext) (string, error) {
+	filterHash, err := hashstructure.Hash(sc.filter, nil)
+	if err != nil {
+		return "", err
+	}
+	res := fmt.Sprintf("%s %v %v %v", schemaID, sc.join, filterHash, sc.fields)
+	if sc.paginator != nil {
+		res = fmt.Sprintf("%s %v", res, *sc.paginator)
+	}
+	return res, err
+}
+
+func (tx *CachedTransaction) getCached(schemeID string, sc *selectContext) (list []*schema.Resource, total uint64, wasCached bool, wasLocked bool, err error) {
+	key, err := tx.createKey(schemeID, sc)
+	if err != nil {
+		return nil, 0, false, false, err
+	}
+
+	res, present := tx.QueryCache[key]
+	if present {
+		return res.list, res.total, true, res.isLocked, nil
+	} else {
+		return nil, 0, false, false, nil
+	}
+}
+
+func (tx *CachedTransaction) saveCache(schemeID string, sc *selectContext, list []*schema.Resource, total uint64, wasLocked bool, errList error) error {
+	if errList != nil {
+		return nil
+	}
+	key, err := tx.createKey(schemeID, sc)
+	if err != nil {
+		return err
+	}
+	tx.QueryCache[key] = CachedState{list, total, wasLocked}
+	return nil
+}
+
+func (tx *CachedTransaction) ClearCache() {
+	tx.QueryCache = make(map[string]CachedState)
+}
+
+func (tx *CachedTransaction) LockList(s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator, lockPolicy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
+	return tx.LockListContext(context.Background(), s, filter, options, pg, lockPolicy)
+}
+
+func (tx *CachedTransaction) LockListContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator, lockPolicy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
+
+	sc := lockListContextHelper(s, filter, options, pg, lockPolicy)
+
+	list, total, wasCached, wasLocked, err := tx.getCached(s.ID, sc)
+	if err != nil {
+		return
+	}
+
+	if !wasCached || !wasLocked {
+		if wasCached {
+			metrics.UpdateCounter(1, "tx.%s.cache.notLocked", s.ID)
+		}
+		metrics.UpdateCounter(1, "tx.%s.cache.missLock", s.ID)
+
+		list, total, err = tx.TxInterface.LockListContext(ctx, s, filter, options, pg, lockPolicy)
+		tx.saveCache(s.ID, sc, list, total, true, err)
+	} else {
+		metrics.UpdateCounter(1, "tx.%s.cache.hitLock", s.ID)
+	}
+	return
+}
+
+func (tx *CachedTransaction) Query(s *schema.Schema, query string, arguments []interface{}) (list []*schema.Resource, err error) {
+	return tx.QueryContext(context.Background(), s, query, arguments)
+}
+
+func (tx *CachedTransaction) QueryContext(ctx context.Context, s *schema.Schema, query string, arguments []interface{}) (list []*schema.Resource, err error) {
+	tx.ClearCache()
+	return tx.TxInterface.QueryContext(context.Background(), s, query, arguments)
+}
+
+func (tx *CachedTransaction) Fetch(s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions) (*schema.Resource, error) {
+	return tx.FetchContext(context.Background(), s, filter, options)
+}
+
+func (tx *CachedTransaction) FetchContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions) (*schema.Resource, error) {
+	list, _, err := tx.ListContext(ctx, s, filter, options, nil)
+	return fetchContextHelper(list, err, filter)
+}
+
+func (tx *CachedTransaction) LockFetch(s *schema.Schema, filter transaction.Filter, lockPolicy schema.LockPolicy, options *transaction.ViewOptions) (*schema.Resource, error) {
+	return tx.LockFetchContext(context.Background(), s, filter, lockPolicy, options)
+}
+
+func (tx *CachedTransaction) LockFetchContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, lockPolicy schema.LockPolicy, options *transaction.ViewOptions) (*schema.Resource, error) {
+	list, _, err := tx.LockListContext(ctx, s, filter, nil, nil, lockPolicy)
+	return lockFetchContextHelper(err, list, filter)
+}

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -72,6 +72,8 @@ type Transaction struct {
 	isolationLevel transaction.Type
 }
 
+type TxInterface transaction.Transaction
+
 func mapTxOptions(options *transaction.TxOptions) (*sql.TxOptions, error) {
 	sqlOptions := &sql.TxOptions{}
 	switch options.IsolationLevel {
@@ -355,6 +357,7 @@ func (db *DB) Begin() (tx transaction.Transaction, err error) {
 	db.updateCounter(1, "begin.waiting")
 	defer db.updateCounter(-1, "begin.waiting")
 
+	var transx Transaction
 	rawTx, err := db.DB.Beginx()
 	if err != nil {
 		db.updateCounter(1, "begin.failed")
@@ -365,17 +368,20 @@ func (db *DB) Begin() (tx transaction.Transaction, err error) {
 	if db.sqlType == "sqlite3" {
 		rawTx.Exec("PRAGMA foreign_keys = ON;")
 	}
-	tx = &Transaction{
+	transx = Transaction{
 		db:             db,
 		transaction:    rawTx,
 		closed:         false,
 		isolationLevel: transaction.RepeatableRead,
 	}
+
 	if os.Getenv("FUZZY_DB_TX") == "true" {
 		log.Notice("FUZZY_DB_TX is enabled")
-		tx = &transaction.FuzzyTransaction{Tx: tx}
+		tx = &transaction.FuzzyTransaction{Tx: transaction.Transaction(&transx)}
+	} else {
+		tx = MakeCachedTransaction(&transx)
 	}
-	log.Debug("[%p] Created transaction %#v, isolation level: %s", rawTx, rawTx, tx.GetIsolationLevel())
+	log.Debug("[%p] Created transaction %#v, isolation level: %s", rawTx, rawTx, transx.GetIsolationLevel())
 	return
 }
 
@@ -385,6 +391,7 @@ func (db *DB) BeginTx(ctx context.Context, options *transaction.TxOptions) (tx t
 	db.updateCounter(1, "begin.waiting")
 	defer db.updateCounter(-1, "begin.waiting")
 
+	var transx Transaction
 	sqlOptions, err := mapTxOptions(options)
 	if err != nil {
 		return nil, err
@@ -399,13 +406,19 @@ func (db *DB) BeginTx(ctx context.Context, options *transaction.TxOptions) (tx t
 	if db.sqlType == "sqlite3" {
 		rawTx.Exec("PRAGMA foreign_keys = ON;")
 	}
-	tx = &Transaction{
+	transx = Transaction{
 		db:             db,
 		transaction:    rawTx,
 		closed:         false,
 		isolationLevel: options.IsolationLevel,
 	}
-	log.Debug("[%p] Created transaction %#v, isolation level %s", rawTx, rawTx, tx.GetIsolationLevel())
+	if transx.isolationLevel == transaction.RepeatableRead || transx.isolationLevel == transaction.Serializable {
+		tx = MakeCachedTransaction(&transx)
+	} else {
+		tx = &transx
+	}
+
+	log.Debug("[%p] Created transaction %#v, isolation level: %s", rawTx, rawTx, transx.GetIsolationLevel())
 	return
 }
 
@@ -913,6 +926,17 @@ func (tx *Transaction) List(s *schema.Schema, filter transaction.Filter, options
 func (tx *Transaction) ListContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator) (list []*schema.Resource, total uint64, err error) {
 	defer tx.measureTime(time.Now(), s.ID, "list")
 
+	sc := listContextHelper(s, filter, options, pg)
+
+	sql, args, err := buildSelect(sc)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return tx.executeSelect(ctx, sc, sql, args)
+}
+
+func listContextHelper(s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator) *selectContext {
 	sc := &selectContext{
 		schema:    s,
 		filter:    filter,
@@ -923,13 +947,7 @@ func (tx *Transaction) ListContext(ctx context.Context, s *schema.Schema, filter
 		sc.fields = normFields(options.Fields, s)
 		sc.join = options.Details
 	}
-
-	sql, args, err := buildSelect(sc)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return tx.executeSelect(ctx, sc, sql, args)
+	return sc
 }
 
 func shouldJoin(policy schema.LockPolicy) bool {
@@ -952,18 +970,7 @@ func (tx *Transaction) LockList(s *schema.Schema, filter transaction.Filter, opt
 func (tx *Transaction) LockListContext(ctx context.Context, s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator, lockPolicy schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
 	defer tx.measureTime(time.Now(), s.ID, "lock_list")
 
-	policyJoin := shouldJoin(lockPolicy)
-
-	sc := &selectContext{
-		schema:    s,
-		filter:    filter,
-		join:      policyJoin,
-		paginator: pg,
-	}
-	if options != nil {
-		sc.fields = normFields(options.Fields, s)
-		sc.join = policyJoin && options.Details
-	}
+	sc := lockListContextHelper(s, filter, options, pg, lockPolicy)
 
 	sql, args, err := buildSelect(sc)
 	if err != nil {
@@ -982,6 +989,21 @@ func (tx *Transaction) LockListContext(ctx context.Context, s *schema.Schema, fi
 	}
 
 	return tx.executeSelect(ctx, sc, sql, args)
+}
+
+func lockListContextHelper(s *schema.Schema, filter transaction.Filter, options *transaction.ViewOptions, pg *pagination.Paginator, lockPolicy schema.LockPolicy) *selectContext {
+	policyJoin := shouldJoin(lockPolicy)
+	sc := &selectContext{
+		schema:    s,
+		filter:    filter,
+		join:      policyJoin,
+		paginator: pg,
+	}
+	if options != nil {
+		sc.fields = normFields(options.Fields, s)
+		sc.join = policyJoin && options.Details
+	}
+	return sc
 }
 
 func (tx *Transaction) Query(s *schema.Schema, query string, arguments []interface{}) (list []*schema.Resource, err error) {
@@ -1088,6 +1110,10 @@ func (tx *Transaction) FetchContext(ctx context.Context, s *schema.Schema, filte
 	defer tx.measureTime(time.Now(), s.ID, "fetch")
 
 	list, _, err := tx.ListContext(ctx, s, filter, options, nil)
+	return fetchContextHelper(list, err, filter)
+}
+
+func fetchContextHelper(list []*schema.Resource, err error, filter transaction.Filter) (*schema.Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch %s: %s", filter, err)
 	}
@@ -1106,6 +1132,10 @@ func (tx *Transaction) LockFetchContext(ctx context.Context, s *schema.Schema, f
 	defer tx.measureTime(time.Now(), s.ID, "lock_fetch")
 
 	list, _, err := tx.LockListContext(ctx, s, filter, nil, nil, lockPolicy)
+	return lockFetchContextHelper(err, list, filter)
+}
+
+func lockFetchContextHelper(err error, list []*schema.Resource, filter transaction.Filter) (*schema.Resource, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to fetch and lock %s: %s", filter, err)
 	}

--- a/db/transaction/transaction_test.go
+++ b/db/transaction/transaction_test.go
@@ -16,8 +16,15 @@
 package transaction_test
 
 import (
+	"context"
+
+	"github.com/cloudwan/gohan/db/pagination"
+	"github.com/cloudwan/gohan/db/sql"
+	"github.com/cloudwan/gohan/db/transaction"
 	tx "github.com/cloudwan/gohan/db/transaction"
+	"github.com/cloudwan/gohan/db/transaction/mocks"
 	"github.com/cloudwan/gohan/schema"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -48,6 +55,144 @@ var _ = Describe("Transaction", func() {
 
 		It("Gets schema overrides", func() {
 			Expect(tx.GetIsolationLevel(netSchema, "update")).To(Equal(tx.Serializable))
+		})
+	})
+
+	Describe("CachedTransactionTest", func() {
+		var transx *mocks.MockTransaction
+		var cachedTx *sql.CachedTransaction
+		var count int
+		var countLock int
+		var mockCtrl *gomock.Controller
+
+		BeforeEach(func() {
+			mockCtrl = gomock.NewController(GinkgoT())
+			transx = mocks.NewMockTransaction(mockCtrl)
+			cachedTx = &sql.CachedTransaction{transx, nil}
+			cachedTx.ClearCache()
+
+			manager := schema.GetManager()
+			basePath := "../../tests/test_abstract_schema.yaml"
+			Expect(manager.LoadSchemaFromFile(basePath)).To(Succeed())
+
+			schemaPath := "../../tests/test_schema.yaml"
+			Expect(manager.LoadSchemaFromFile(schemaPath)).To(Succeed())
+			netSchema, _ = manager.Schema("network")
+
+			countLock = 0
+			count = 0
+			transx.EXPECT().ListContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, *schema.Schema, transaction.Filter, *transaction.ViewOptions, *pagination.Paginator) (list []*schema.Resource, total uint64, err error) {
+				count++
+				return []*schema.Resource{}, 0, nil
+			}).AnyTimes()
+
+			transx.EXPECT().LockListContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(context.Context, *schema.Schema, transaction.Filter, *transaction.ViewOptions, *pagination.Paginator, schema.LockPolicy) (list []*schema.Resource, total uint64, err error) {
+				countLock++
+				return []*schema.Resource{}, 0, nil
+			}).AnyTimes()
+
+			transx.EXPECT().CreateContext(gomock.Any(), gomock.Any()).AnyTimes()
+			transx.EXPECT().UpdateContext(gomock.Any(), gomock.Any()).AnyTimes()
+			transx.EXPECT().DeleteContext(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+			transx.EXPECT().QueryContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		})
+		AfterEach(func() {
+			mockCtrl.Finish()
+		})
+
+		It("First list not cached", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+		})
+
+		It("List calls get cached", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			Expect(countLock).To(Equal(0))
+			cachedTx.LockList(netSchema, tx.Filter{}, nil, nil, schema.LockRelatedResources)
+			Expect(count).To(Equal(1))
+			Expect(countLock).To(Equal(1))
+			cachedTx.LockList(netSchema, tx.Filter{}, nil, nil, schema.SkipRelatedResources)
+			Expect(count).To(Equal(1))
+			Expect(countLock).To(Equal(2)) //Lock policy changes hash
+		})
+
+		It("Fetch calls get cached", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.Fetch(netSchema, tx.Filter{}, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.Fetch(netSchema, tx.Filter{}, nil)
+			Expect(count).To(Equal(1))
+		})
+
+		It("ListCtx calls get cached", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.ListContext(nil, netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.ListContext(nil, netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.LockListContext(nil, netSchema, tx.Filter{}, nil, nil, schema.LockRelatedResources)
+			Expect(count).To(Equal(1))
+			cachedTx.LockListContext(nil, netSchema, tx.Filter{}, nil, nil, schema.SkipRelatedResources)
+			Expect(count).To(Equal(1))
+		})
+
+		It("FetchCtx calls get cached", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.FetchContext(nil, netSchema, tx.Filter{}, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.FetchContext(nil, netSchema, tx.Filter{}, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.LockFetchContext(nil, netSchema, tx.Filter{}, schema.LockRelatedResources, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.LockFetchContext(nil, netSchema, tx.Filter{}, schema.SkipRelatedResources, nil)
+			Expect(count).To(Equal(1))
+		})
+
+		It("Updates / inserts clear cache", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.Create(nil)
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(2))
+			cachedTx.Update(nil)
+			Expect(count).To(Equal(2))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(3))
+			cachedTx.Delete(nil, nil)
+			Expect(count).To(Equal(3))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(4))
+			cachedTx.Query(nil, "", nil)
+			Expect(count).To(Equal(4))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(5))
+		})
+
+		It("Updates / inserts with ctx clear cache", func() {
+			Expect(count).To(Equal(0))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(1))
+			cachedTx.CreateContext(nil, nil)
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(2))
+			cachedTx.UpdateContext(nil, nil)
+			Expect(count).To(Equal(2))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(3))
+			cachedTx.DeleteContext(nil, nil, nil)
+			Expect(count).To(Equal(3))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(4))
+			cachedTx.QueryContext(nil, nil, "", nil)
+			Expect(count).To(Equal(4))
+			cachedTx.List(netSchema, tx.Filter{}, nil, nil)
+			Expect(count).To(Equal(5))
 		})
 	})
 })

--- a/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,65 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+  
+  * Optionally hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,358 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// ErrNotStringer is returned when there's an error with hash:"string"
+type ErrNotStringer struct {
+	Field string
+}
+
+// Error implements error for ErrNotStringer
+func (ens *ErrNotStringer) Error() string {
+	return fmt.Sprintf("hashstructure: %s has hash:\"string\" set, but does not implement fmt.Stringer", ens.Field)
+}
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values. The same *HashOptions value cannot be used
+// concurrently. None of the values within a *HashOptions struct are
+// safe to read/write while hashing is being done.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+//   * "string" - The field will be hashed as a string, only works when the
+//                field implements fmt.Stringer
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		parent := v.Interface()
+		var include Includable
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if innerV := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// if string is set, use the string value
+				if tag == "string" {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+					} else {
+						return 0, &ErrNotStringer{
+							Field: v.Type().Field(i).Name,
+						}
+					}
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(innerV, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -778,6 +778,12 @@
 			"revisionTime": "2016-11-18T19:16:01Z"
 		},
 		{
+			"checksumSHA1": "tWUjKyFOGJtYExocPWVYiXBYsfE=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "2bca23e0e452137f789efbc8610126fd8b94f73b",
+			"revisionTime": "2017-06-09T04:59:27Z"
+		},
+		{
 			"checksumSHA1": "3eh8eN6S9vHn8UcoFfD9BAP9K9E=",
 			"path": "github.com/mitchellh/mapstructure",
 			"revision": "442e588f213303bec7936deba67901f8fc8f18b1"


### PR DESCRIPTION
Add wrapper for transaction.Transaction that caches select requests results and returns results from cache instead of making another call to the db. All operations that could influence requests results clear the cache, so we make another call to the db when needed.