### PR TITLE
Treat empty strings as undefined during unmarshalling

### DIFF
--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -308,6 +308,10 @@ func (util *Util) ResourceToMap(resource interface{}) map[string]interface{} {
 			}
 		} else if v.Kind() == reflect.Struct {
 			fieldsMap[fieldName] = util.ResourceToMap(v.Addr().Interface())
+		} else if v.Kind() == reflect.String {
+			if v.String() != "" {
+				fieldsMap[fieldName] = val
+			}
 		} else {
 			fieldsMap[fieldName] = val
 		}

--- a/extension/goplugin/util_test.go
+++ b/extension/goplugin/util_test.go
@@ -680,5 +680,17 @@ var _ = Describe("Util tests", func() {
 			})
 		})
 
+		It("Empty string value in primitive string is treated as undefined", func() {
+			type TestResource struct {
+				String string `json:"string"`
+			}
+
+			input := &TestResource{
+				String: "",
+			}
+			expected := map[string]interface{}{}
+
+			Expect(env.Util().ResourceToMap(input)).To(Equal(expected))
+		})
 	})
 })


### PR DESCRIPTION
This is a workaround for issue which prohibits doing request validation in PreUpdate events using golang extensions. Structures provided to schema handlers which has fields with `string` type will be filled with empty string during allocation. When user doesn't provide this field in his request body, he don't intents to update it, but rather leave value as it is. Current code will try to update each of these fields to empty strings, which is not expected behavior. Additionally validation may fail because some fields may require that length is not 0. 