### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# List of default reviewers for all changes in gohan
+* @morrisson @marcin-ptaszynski @p-kozlowski @zimnx @michalzurawski @jkmar @aleksander-bulanowski


### PR DESCRIPTION
This file should cause all listed users to be automatically added for review on every PR.

To make it work someone with admin access must also select "Require review from code owners" in repository settings. (https://help.github.com/articles/enabling-required-reviews-for-pull-requests/)