### PR TITLE
Create indices based on an actual table name, rather than 'plural' parameter

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -485,8 +485,8 @@ func (db *DB) genTableCols(s *schema.Schema, cascade bool, exclude []string) ([]
 			if sqlDataType == "text" && db.sqlType == "mysql" {
 				prefix = "(255)"
 			}
-			indices = append(indices, fmt.Sprintf("CREATE INDEX %s_%s_idx ON `%s`(`%s`%s);", s.Plural, property.ID,
-				s.Plural, property.ID, prefix))
+			indices = append(indices, fmt.Sprintf("CREATE INDEX %s_%s_idx ON `%s`(`%s`%s);", s.GetDbTableName(), property.ID,
+				s.GetDbTableName(), property.ID, prefix))
 		}
 	}
 


### PR DESCRIPTION
In current form, indices are being created based on `Plural` parameter, which is different than expected behaviour. This PR makes changes, so that database table name is used. This is accomplished by using `GetDbTableName()` function instead of the aforementioned `Plural` parameter.

For example, when using a schema:
```
id: puppy
  plural: puppies
  (...)
```
we expect database name to be `puppys`, not `puppies`.

Hence the proper index creation command should look like this:
```CREATE INDEX puppys_name_idx ON `puppys`(`name`);```
but in current version it looks like this:
```CREATE INDEX puppies_name_idx ON `puppies`(`name`);```.