### PR TITLE
Remove windows from crosscompile target

### DIFF
--- a/tools/crosscompile.sh
+++ b/tools/crosscompile.sh
@@ -3,7 +3,7 @@
 mkdir dist
 rm -rf dist/*
 cd dist
-xgo --targets=windows/amd64,linux/amd64 github.com/cloudwan/gohan
+xgo --targets=linux/amd64 github.com/cloudwan/gohan
 for binary in $(ls); do
     zip -r ${binary}.zip ${binary}
     rm -rf ${binary}


### PR DESCRIPTION
PR #658 led the failure of deployment section of circle CI.
Practically, we did not meet the use case where gohan is running on
Windows OS, so let's remove it so far.

See: https://circleci.com/gh/cloudwan/gohan/1945