### PR TITLE
CW-594 fix keystone v3 reauth

### DIFF
--- a/cloud/keystone_test_utils.go
+++ b/cloud/keystone_test_utils.go
@@ -49,6 +49,31 @@ func getV3TokensResponse() interface{} {
 				"id":   "1234",
 				"name": "admin",
 			},
+			"roles": []interface{}{
+				map[string]interface{}{
+					"id":   "51cc68287d524c759f47c811e6463340",
+					"name": "member",
+				},
+			},
+			"catalog": []interface{}{},
+			"project": map[string]interface{}{
+				"domain": map[string]interface{}{
+					"id":   "default",
+					"name": "default",
+				},
+				"id":   "acme-id",
+				"name": "acme",
+			},
+		},
+	}
+}
+
+func getV3Unauthorized() interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": "The request you have made requires authentication.",
+			"code":    401,
+			"title":   "Unauthorized",
 		},
 	}
 }

--- a/extension/gohanscript/lib/openstack.go
+++ b/extension/gohanscript/lib/openstack.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-
-	"github.com/cloudwan/gohan/cloud"
 )
 
 func newClient(endpoint string) (*gophercloud.ProviderClient, error) {
@@ -82,7 +80,6 @@ func GetOpenstackClient(authURL, userName, password, domainName, tenantName, ten
 	if err != nil {
 		return nil, err
 	}
-	client.HTTPClient = cloud.NewHTTPClient()
 	if version == "v2.0" {
 		return openstack.NewIdentityV2(client, gophercloud.EndpointOpts{})
 	} else if version == "v3" {


### PR DESCRIPTION
- remove RoundTripper limiting reauth attempts, since new
  gophercloud handles it properly (1 retry).
- fix token response handling.