### PR TITLE
[BL-267] Handle blacklisted tenant_id when creating resource

### DIFF
--- a/schema/policy.go
+++ b/schema/policy.go
@@ -750,8 +750,24 @@ func (p *Policy) FilterSchema(
 		filter.RemoveHiddenKeysFromSlice(required)
 }
 
-//Checks if user is authorized to perform given action
-func (p *Policy) Check(action string, authorization Authorization, data map[string]interface{}) error {
+// Checks if user is authorized to perform given action and to access given properties
+func (p *Policy) Check(action string, authorization Authorization, data map[string]interface{},
+) error {
+	if err := p.CheckAccess(action, authorization, data); err != nil {
+		return err
+	}
+
+	if err := p.CheckPropertiesFilter(data); data != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Checks if user is authorized to perform given action
+func (p *Policy) CheckAccess(action string, authorization Authorization,
+	data map[string]interface{}) error {
+
 	currCond := p.GetCurrentResourceCondition()
 	if currCond.RequireOwner() {
 		if err := authorization.checkAccessToResource(currCond, action, data); err != nil {
@@ -759,6 +775,11 @@ func (p *Policy) Check(action string, authorization Authorization, data map[stri
 		}
 	}
 
+	return nil
+}
+
+// Checks if any given properties are prohibited
+func (p *Policy) CheckPropertiesFilter(data map[string]interface{}) error {
 	for key := range data {
 		if key == "tenant_name" {
 			continue

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -439,6 +439,12 @@ func (schema *Schema) GetPropertyByID(id string) (*Property, error) {
 	return nil, fmt.Errorf("Property with ID %s not found in schema %s", id, schema.ID)
 }
 
+// HasPropertyID checks if given property is in schema
+func (schema *Schema) HasPropertyID(id string) bool {
+	_, err := schema.GetPropertyByID(id)
+	return err == nil
+}
+
 //StateVersioning whether resources created from this schema should track state and config versions
 func (schema *Schema) StateVersioning() bool {
 	statefulRaw, ok := schema.Metadata["state_versioning"]

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -108,6 +108,41 @@ var _ = Describe("Schema", func() {
 		})
 	})
 
+	Describe("Properties access", func() {
+		var manager *Manager
+		var schema *Schema
+
+		BeforeEach(func() {
+			manager = GetManager()
+			Expect(manager.LoadSchemasFromFiles(
+				"../tests/test_schema_property_order.yaml")).To(Succeed())
+
+			s, ok := manager.Schema("school")
+			Expect(ok).To(BeTrue())
+			schema = s
+		})
+
+		It("should access properties", func() {
+			property, err := schema.GetPropertyByID("best_in_town")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(property.ID).To(Equal("best_in_town"))
+		})
+
+		It("should err on access of undefined properties", func() {
+			_, err := schema.GetPropertyByID("unknown")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should check property existence", func() {
+			Expect(schema.HasPropertyID("patron")).To(BeTrue())
+			Expect(schema.HasPropertyID("best_in_town")).To(BeTrue())
+
+			Expect(schema.HasPropertyID("unknown")).To(BeFalse())
+			Expect(schema.HasPropertyID("some_property_not_in_schema")).To(BeFalse())
+		})
+	})
+
 	Describe("Properties order", func() {
 		var manager *Manager
 

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -1011,6 +1011,10 @@ var _ = Describe("Resource manager", func() {
 
 		Describe("When there are no resources in the database", func() {
 			Context("As an admin", func() {
+				BeforeEach(func() {
+					auth = adminAuth
+				})
+
 				It("Should create own resource", func() {
 					err := resources.CreateResource(
 						context, testDB, fakeIdentity, currentSchema, adminResourceData)
@@ -1042,13 +1046,16 @@ var _ = Describe("Resource manager", func() {
 
 				It("Should fill in the tenant_id", func() {
 					err := resources.CreateResource(
-						context, testDB, fakeIdentity, currentSchema, map[string]interface{}{"id": adminResourceID, "domain_id": domainAID})
+						context, testDB, fakeIdentity, currentSchema, map[string]interface{}{
+							"id":        adminResourceID,
+							"domain_id": domainAID,
+						})
 					result := context["response"].(map[string]interface{})
 					Expect(err).NotTo(HaveOccurred())
 					theResource, ok := result[schemaID]
 					Expect(ok).To(BeTrue())
 					Expect(theResource).To(HaveKeyWithValue("domain_id", domainAID))
-					Expect(theResource).To(HaveKeyWithValue("tenant_id", adminTenantID))
+					Expect(theResource).To(HaveKeyWithValue("tenant_id", auth.TenantID()))
 					Expect(theResource).To(HaveKeyWithValue("id", adminResourceID))
 				})
 
@@ -1059,7 +1066,7 @@ var _ = Describe("Resource manager", func() {
 					Expect(err).NotTo(HaveOccurred())
 					theResource, ok := result[schemaID]
 					Expect(ok).To(BeTrue())
-					Expect(theResource).To(HaveKeyWithValue("domain_id", schema.DefaultDomain.ID))
+					Expect(theResource).To(HaveKeyWithValue("domain_id", auth.DomainID()))
 					Expect(theResource).To(HaveKeyWithValue("tenant_id", adminTenantID))
 					Expect(theResource).To(HaveKeyWithValue("id", adminResourceID))
 				})
@@ -1071,8 +1078,8 @@ var _ = Describe("Resource manager", func() {
 					result := context["response"].(map[string]interface{})
 					theResource, ok := result[schemaID]
 					Expect(ok).To(BeTrue())
-					Expect(theResource).To(HaveKeyWithValue("domain_id", schema.DefaultDomain.ID))
-					Expect(theResource).To(HaveKeyWithValue("tenant_id", adminTenantID))
+					Expect(theResource).To(HaveKeyWithValue("domain_id", auth.DomainID()))
+					Expect(theResource).To(HaveKeyWithValue("tenant_id", auth.TenantID()))
 					Expect(theResource).To(HaveKey("id"))
 				})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -448,13 +448,14 @@ var _ = Describe("Server package test", func() {
 			Expect(result).To(HaveKeyWithValue("network", networkExpected))
 
 			result = testURL("GET", baseURL+"/_all", memberTokenID, nil, http.StatusOK)
-			Expect(result).To(HaveLen(9))
+			Expect(result).To(HaveLen(10))
 			Expect(result).To(HaveKeyWithValue("networks", []interface{}{networkExpected}))
 			Expect(result).To(HaveKey("schemas"))
 			Expect(result).To(HaveKey("tests"))
 			Expect(result).To(HaveKey("attachers"))
 			Expect(result).To(HaveKey("wildcard_attachers"))
 			Expect(result).To(HaveKey("attach_targets"))
+			Expect(result).To(HaveKey("blacklisted_tenant_ids"))
 
 			testURL("GET", baseURL+"/v2.0/network/unknownID", memberTokenID, nil, http.StatusNotFound)
 

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -8,6 +8,7 @@ schemas:
     - "../tests/test_schema_sync.yaml"
     - "../tests/test_two_same_relations_schema.yaml"
     - "../tests/test_sync_watch_extension.yaml"
+    - "../tests/test_blacklisted_tenant_id_schema.yaml"
 address: ":19090"
 document_root: "embed"
 sync: etcdv3

--- a/tests/test_blacklisted_tenant_id_schema.yaml
+++ b/tests/test_blacklisted_tenant_id_schema.yaml
@@ -1,0 +1,69 @@
+schemas:
+- id: blacklisted_tenant_id
+  description: Test Blacklisted/Hidden tenant_id
+  singular: blacklisted_tenant_id
+  plural: blacklisted_tenant_ids
+  prefix: /v2.0
+  schema:
+    properties:
+      id:
+        description: ID
+        permission:
+        - create
+        title: ID
+        type: string
+        unique: true
+      myprop:
+        description: Custom Property
+        permission:
+        - create
+        - update
+        title: MyProp
+        type: string
+      tenant_id:
+        description: Tenant ID
+        permission:
+        - create
+        - update
+        title: TenantID
+        type: string
+        unique: false
+        indexed: true
+      domain_id:
+        description: Domain ID
+        permission:
+        - create
+        - update
+        title: DomainID
+        type: string
+        unique: false
+        indexed: true
+    propertiesOrder:
+    - id
+    - myprop
+    - tenant_id
+    - domain_id
+    type: object
+  title: Test blacklisted tenant_id
+
+policies:
+- action: create
+  effect: allow
+  id: blacklisted_tenant_id_create_member
+  principal: Member
+  condition:
+  - is_owner
+  resource:
+    path: /v2.0/blacklisted_tenant_id.*
+    blacklistProperties:
+    - tenant_id
+- action: update
+  effect: allow
+  id: blacklisted_tenant_id_update_member
+  principal: Member
+  condition:
+  - is_owner
+  resource:
+    path: /v2.0/blacklisted_tenant_id.*
+    blacklistProperties:
+    - tenant_id

--- a/tests/test_blacklisted_tenant_id_schema.yaml
+++ b/tests/test_blacklisted_tenant_id_schema.yaml
@@ -67,3 +67,11 @@ policies:
     path: /v2.0/blacklisted_tenant_id.*
     blacklistProperties:
     - tenant_id
+- action: read
+  effect: allow
+  id: blacklisted_tenant_id_read_member
+  principal: Member
+  condition:
+  - is_owner
+  resource:
+    path: /v2.0/blacklisted_tenant_id.*


### PR DESCRIPTION
BL-267: handle blacklisted tenant_id when creating resource.

We would always fail to create a resource when tenant_id is
blacklisted in a matching policy. This was due to the fact that we
filled the tenant_id field if it was not provided and was also defined
in the schema. That way we always matched the blacklist filter.

This fix is implemented by splitting Policy.Check method into two new
methods: CheckAccess and CheckPropertiesFilter. CheckAccess receives
the filled in tenant_id/domain_id as it requires that info to perform
authorization. CheckPropertiesFilter receives all the original
parameters without those additionally filled in. So if tenant_id was
not provided, it will not match against the blacklist/hidden filter.
Updating resource was not performing any tenant_id/domain_id filling,
so it still used the Check method (which is now implemented using the
extracted methods) as it leads to simpler code. And to smaller diff.

Added HasPropertyId method to Schema as a simple wrapper of
GetPropertyById, to simplify those call sites that do not need to
access the property, just to check its existence. Added tests for both
while at it.