### PR TITLE
Change golint import path

### DIFF
--- a/tools/dev_setup.sh
+++ b/tools/dev_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 go get -u github.com/kardianos/govendor
-go get -u github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 go get -u github.com/gordonklaus/ineffassign
 go get -u github.com/jteeuwen/go-bindata/go-bindata
 go get -u github.com/client9/misspell/cmd/misspell


### PR DESCRIPTION
Because of recent changes in golint repository, it's enforced that golint package must be imported from golang.org/x/lint/golint. This commit changes dev_setup script to pull proper version