### PR TITLE
Introduce admin_statement for admin-scoped token into gohan.json

### DIFF
--- a/etc/schema/gohan.json
+++ b/etc/schema/gohan.json
@@ -1,4 +1,16 @@
 {
+    "policies": [
+        {
+            "action": "*",
+            "effect": "allow",
+            "id": "admin_statement",
+            "principal": "admin",
+            "resource": {
+                "path": ".*"
+            },
+            "scope": ["admin"]
+        }
+    ],
     "schemas": [
         {
             "description": "The main metaschema",


### PR DESCRIPTION
With scope property support added, admin_statement policy can now be reintroduced into the gohan.json file.