### PR TITLE
Go 1.11 support and test stability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.11.4
     working_directory: /go/src/github.com/cloudwan/gohan
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
       - run: make deps gen lint build
   test:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.11.4
     working_directory: /go/src/github.com/cloudwan/gohan
     steps:
       - checkout

--- a/extension/otto/otto_suite_test.go
+++ b/extension/otto/otto_suite_test.go
@@ -34,7 +34,7 @@ const (
 	configDir         = "../../server"
 	configFile        = "./server_test_config.yaml"
 	dbType            = "sqlite3"
-	dbFile            = "./test.db"
+	dbFile            = "./otto_test.db"
 	testSyncEndpoint  = "localhost:2379"
 	adminTokenID      = "admin_token"
 	memberTokenID     = "demo_token"

--- a/extension/otto/otto_test.go
+++ b/extension/otto/otto_test.go
@@ -602,7 +602,7 @@ var _ = Describe("Otto extension manager", func() {
 
 			context := makeContext()
 			Expect(env.HandleEvent("test_event", context)).To(Succeed())
-			Expect(context).To(HaveKeyWithValue("resp", HaveKeyWithValue("connection", "test.db")))
+			Expect(context).To(HaveKeyWithValue("resp", HaveKeyWithValue("connection", "server_test.db")))
 			Expect(context).To(HaveKeyWithValue("resp", HaveKeyWithValue("type", "sqlite3")))
 		})
 
@@ -2219,10 +2219,10 @@ var _ = Describe("Using gohan_file builtin", func() {
 		It("Should work", func() {
 			extension, err := schema.NewExtension(map[string]interface{}{
 				"id": "read_file",
-				"code": `
+				"code": fmt.Sprintf(`
 					gohan_register_handler("test_event", function(context){
-						context.list = gohan_file_read('./test.db');
-					});`,
+						context.list = gohan_file_read('%s');
+					});`, dbFile),
 				"path": ".*",
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -2254,10 +2254,10 @@ var _ = Describe("Using gohan_file builtin", func() {
 		It("Should work", func() {
 			extension, err := schema.NewExtension(map[string]interface{}{
 				"id": "read_file_cd",
-				"code": `
+				"code": fmt.Sprintf(`
 					gohan_register_handler("test_event", function(context){
-						context.list = gohan_file_read_cd('./test.db');
-					});`,
+						context.list = gohan_file_read_cd('%s');
+					});`, dbFile),
 				"path": ".*",
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -2305,10 +2305,10 @@ var _ = Describe("Using gohan_file builtin", func() {
 		It("Isn't dir", func() {
 			extension, err := schema.NewExtension(map[string]interface{}{
 				"id": "read_file",
-				"code": `
+				"code": fmt.Sprintf(`
 					gohan_register_handler("test_event", function(context){
-						context.dir= gohan_file_dir('./test.db');
-					});`,
+						context.dir= gohan_file_dir('%s');
+					});`, dbFile),
 				"path": ".*",
 			})
 			Expect(err).ToNot(HaveOccurred())

--- a/run_test.sh
+++ b/run_test.sh
@@ -9,7 +9,7 @@ if [[ $MYSQL_TEST == "true" ]]; then
 fi
 
 DATA_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
-etcd -data-dir $DATA_DIR --listen-peer-urls http://:2380 --listen-client-urls http://:2379 --advertise-client-urls http://127.0.0.1:2379 &
+etcd -data-dir $DATA_DIR --listen-peer-urls http://127.0.0.1:2380 --listen-client-urls http://127.0.0.1:2379 --advertise-client-urls http://127.0.0.1:2379 &
 ETCD_PID=$!
 
 echo "mode: count" > profile.cov

--- a/server/resources/resource_management_test.go
+++ b/server/resources/resource_management_test.go
@@ -49,8 +49,6 @@ var _ = Describe("Resource manager", func() {
 		adminAuth               schema.Authorization
 		memberAuth              schema.Authorization
 		domainScopedAuth        schema.Authorization
-		otherDomainMemberAuth   schema.Authorization
-		otherDomainScopedAuth   schema.Authorization
 		auth                    schema.Authorization
 		context                 middleware.Context
 		schemaID                string
@@ -90,19 +88,6 @@ var _ = Describe("Resource manager", func() {
 		domainScopedAuth = schema.NewAuthorizationBuilder().
 			WithDomain(domainA).
 			WithRoleIDs("Member").
-			BuildScopedToDomain()
-
-		domainB := schema.Domain{
-			ID:   domainBID,
-			Name: "domainB",
-		}
-
-		otherDomainMemberAuth = schema.NewAuthorizationBuilder().
-			WithTenant(schema.Tenant{ID: otherDomainTenantID, Name: "richard"}).
-			WithDomain(domainB).
-			BuildScopedToTenant()
-		otherDomainScopedAuth = schema.NewAuthorizationBuilder().
-			WithDomain(domainB).
 			BuildScopedToDomain()
 
 		auth = adminAuth

--- a/server/server_suite_test.go
+++ b/server/server_suite_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Suite set up and tear down", func() {
 		conn = "root@/gohan_test"
 		dbType = "mysql"
 	} else {
-		conn = "./test.db"
+		conn = "./server_test.db"
 		dbType = "sqlite3"
 	}
 

--- a/server/server_test_config.yaml
+++ b/server/server_test_config.yaml
@@ -1,6 +1,6 @@
 database:
     type: "sqlite3"
-    connection: "test.db"
+    connection: "server_test.db"
 schemas:
     - "embed://etc/schema/gohan.json"
     - "../tests/test_abstract_schema.yaml"


### PR DESCRIPTION
This PR improves test stability: on my machine, server and otto tests failed all the time before because they used the same db file. It also fixes one issue reported by `go test` when using go 1.11.