### PR TITLE
Take advantage of reflectx.Mapper's internal cache.

### DIFF
--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync"
 
 	"github.com/cloudwan/gohan/db/transaction"
 	"github.com/cloudwan/gohan/extension/goext"
@@ -260,18 +259,11 @@ func sliceToMap(context map[string]interface{}, fieldName string, field reflect.
 	return nil
 }
 
-var (
-	jsonMapperInitOnce sync.Once
-	jsonMapper         *reflectx.Mapper
-)
+var jsonMapper *reflectx.Mapper = reflectx.NewMapper("json")
 
 // ResourceToMap converts structure representation of the resource to mapped representation
 func (util *Util) ResourceToMap(resource interface{}) map[string]interface{} {
 	fieldsMap := map[string]interface{}{}
-
-	jsonMapperInitOnce.Do(func() {
-		jsonMapper = reflectx.NewMapper("json")
-	})
 
 	structMap := jsonMapper.TypeMap(reflect.TypeOf(resource))
 	resourceValue := reflect.ValueOf(resource).Elem()

--- a/extension/goplugin/util.go
+++ b/extension/goplugin/util.go
@@ -259,7 +259,7 @@ func sliceToMap(context map[string]interface{}, fieldName string, field reflect.
 	return nil
 }
 
-var jsonMapper *reflectx.Mapper = reflectx.NewMapper("json")
+var jsonMapper = reflectx.NewMapper("json")
 
 // ResourceToMap converts structure representation of the resource to mapped representation
 func (util *Util) ResourceToMap(resource interface{}) map[string]interface{} {


### PR DESCRIPTION
Building a StructMap is an expensive operation but fortunately there
is a cache for that inside reflectx's Mapper struct. Unfortunately we
were not using it because for every ResourceToMap call we created a
new mapper instance. This commit changes that to always use one global
mapper instance.

It's hard to measure exact performance improvements for ResourceToMap
run times, because they vary depending on how complex input objects
were. We might say that it is now a couple of times faster. What's
more, our project based on gohan, sees 20% runtime improvement when
running all tests, just because this one function is heavily used
there.

Removed unused Clone method while at it.