### PR TITLE
[BL-355] Do not send Get() request when starting revision is specified

### DIFF
--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -290,6 +290,40 @@ func TestWatchWithRevision(t *testing.T) {
 
 }
 
+func TestShouldStartWatchingAtSpecifiedRevision(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sync := newSync(t)
+	sync.etcdClient.Delete(ctx, "/", etcd.WithPrefix())
+
+	path := "/path/to/watch/with/starting/revision"
+
+	putResponse, err := sync.etcdClient.Put(ctx, path, `{"version": "1"}`)
+	if err != nil {
+		t.Fatalf("failed to update key: %s", err)
+	}
+	firstRevision := putResponse.Header.Revision
+
+	putResponse, err = sync.etcdClient.Put(ctx, path, `{"version": "2"}`)
+	if err != nil {
+		t.Fatalf("failed to update key: %s", err)
+	}
+	secondRevision := putResponse.Header.Revision
+
+	responseChan := sync.Watch(ctx, path, firstRevision-1)
+
+	resp := <-responseChan
+	if resp.Key != path || resp.Data["version"].(string) != "1" || resp.Revision != firstRevision {
+		t.Fatalf("mismatch response: %+v, expecting version==1, revision==%d", resp, firstRevision)
+	}
+
+	resp = <-responseChan
+	if resp.Key != path || resp.Data["version"].(string) != "2" || resp.Revision != secondRevision {
+		t.Fatalf("mismatch response: %+v, expecting version==2, revision==%d", resp, secondRevision)
+	}
+}
+
 func TestFetchMultipleNodes(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
ETCD's API does allow Get() with a selected revision, but it's impossible to express "Get() with a revision equal or greater". When a Watch() is requested starting an given revision, we just omit the call to Get().

Previously the API will return the current revision of the given key, not the one the API user requested. Ie. the newly added test will fail with ```mismatch response: &{Action:get Key:/path/to/watch/with/starting/revision Data:map[version:2] Revision:56501 Err:<nil>}, expecting version==1, revision==56500``` (as seen in the [CI](https://circleci.com/gh/cloudwan/gohan/2613?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)) 