### PR TITLE
Follow SELECT with SELECT COUNT only when required.

### DIFF
--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -871,12 +871,16 @@ func (tx *Transaction) executeSelect(ctx context.Context, sc *selectContext, sql
 		return nil, 0, err
 	}
 
-	if sc.paginator != nil && (sc.paginator.Offset != 0 || sc.paginator.Limit != math.MaxUint64) {
+	if tx.isSelectPaginated(sc) {
 		total, err = tx.Count(ctx, sc.schema, sc.filter)
 	} else {
 		total = uint64(len(list))
 	}
 	return
+}
+
+func (tx *Transaction) isSelectPaginated(sc *selectContext) bool {
+	return sc.paginator != nil && (sc.paginator.Offset != 0 || sc.paginator.Limit != math.MaxUint64)
 }
 
 //List resources in the db

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -871,7 +871,7 @@ func (tx *Transaction) executeSelect(ctx context.Context, sc *selectContext, sql
 		return nil, 0, err
 	}
 
-	if sc.paginator != nil && (sc.paginator.Offset != 0 || sc.paginator.Limit != 0) {
+	if sc.paginator != nil && (sc.paginator.Offset != 0 || sc.paginator.Limit != math.MaxUint64) {
 		total, err = tx.Count(ctx, sc.schema, sc.filter)
 	} else {
 		total = uint64(len(list))

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -870,7 +870,12 @@ func (tx *Transaction) executeSelect(ctx context.Context, sc *selectContext, sql
 	if err != nil {
 		return nil, 0, err
 	}
-	total, err = tx.Count(ctx, sc.schema, sc.filter)
+
+	if sc.paginator != nil && (sc.paginator.Offset != 0 || sc.paginator.Limit != 0) {
+		total, err = tx.Count(ctx, sc.schema, sc.filter)
+	} else {
+		total = uint64(len(list))
+	}
 	return
 }
 

--- a/db/sql/sql_test.go
+++ b/db/sql/sql_test.go
@@ -94,12 +94,17 @@ var _ = Describe("Sql", func() {
 
 	Describe("Select Pagination", func() {
 		var s *schema.Schema
+		var totalBefore uint64
 
 		BeforeEach(func() {
 			manager := schema.GetManager()
 			var ok bool
 			s, ok = manager.Schema("test")
 			Expect(ok).To(BeTrue())
+
+			var err error
+			totalBefore, err = tx.Count(ctx, s, nil)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Empty key doesn't exclude limit/offset pagination", func() {
@@ -109,9 +114,10 @@ var _ = Describe("Sql", func() {
 
 			pg, err := pagination.NewPaginator(pagination.OptionLimit(1))
 			Expect(err).To(Succeed())
-			results, _, err := tx.List(ctx, s, map[string]interface{}{}, nil, pg)
+			results, total, err := tx.List(ctx, s, map[string]interface{}{}, nil, pg)
 			Expect(err).To(Succeed())
 			Expect(len(results)).To(Equal(1))
+			Expect(total).To(Equal(totalBefore + 2))
 		})
 
 	})


### PR DESCRIPTION
After every SELECT we called SELECT COUNT to return total number of
entries in requested table. This can be different than number of
entries returned from SELECT only if we use OFFSET or LIMIT from
paginator.