### PR TITLE
Performance improvement

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -278,7 +278,7 @@ var _ = Describe("Database operation test", func() {
 				})
 
 				It("Shows related resources", func() {
-					list, num, err := tx.List(ctx, serverSchema, nil, nil, nil)
+					list, num, err := tx.List(ctx, serverSchema, nil, &transaction.ViewOptions{Details: true}, nil)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(1)))
 					Expect(list).To(HaveLen(1))

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Database operation test", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(num).To(Equal(uint64(1)))
 					Expect(list).To(HaveLen(1))
-					Expect(list[0].Data()).To(HaveKeyWithValue("network", HaveKeyWithValue("name", BeNil())))
+					Expect(list[0].Data()).ToNot(HaveKey("network"))
 					Expect(tx.Commit()).To(Succeed())
 				})
 
@@ -364,7 +364,7 @@ var _ = Describe("Database operation test", func() {
 				It("Fetches and doesn't lock related resources when requested", func() {
 					networkResourceFetched, err := tx.LockFetch(ctx, serverSchema, nil, schema.SkipRelatedResources, nil)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(networkResourceFetched.Data()).To(HaveKeyWithValue("network", HaveKeyWithValue("name", BeNil())))
+					Expect(networkResourceFetched.Data()).ToNot(HaveKey("network"))
 					Expect(tx.Commit()).To(Succeed())
 				})
 

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -904,7 +904,7 @@ func listContextHelper(s *schema.Schema, filter transaction.Filter, options *tra
 	sc := &selectContext{
 		schema:    s,
 		filter:    filter,
-		join:      true,
+		join:      false,
 		paginator: pg,
 	}
 	if options != nil {

--- a/db/sql/sql.go
+++ b/db/sql/sql.go
@@ -941,13 +941,6 @@ func (tx *Transaction) LockList(ctx context.Context, s *schema.Schema, filter tr
 		sql += " FOR UPDATE"
 	}
 
-	// update join for recursive
-	if options != nil {
-		sc.join = options.Details
-	} else {
-		sc.join = true
-	}
-
 	return tx.executeSelect(ctx, sc, sql, args)
 }
 

--- a/extension/goplugin/transaction.go
+++ b/extension/goplugin/transaction.go
@@ -160,7 +160,14 @@ func (t *Transaction) List(ctx context.Context, schema goext.ISchema, filter goe
 	if err := ctx.Err(); err != nil {
 		return nil, 0, ctx.Err()
 	}
-	data, _, err := t.tx.List(context.Background(), t.findRawSchema(schemaID), transaction.Filter(filter), nil, (*pagination.Paginator)(paginator))
+	var o *transaction.ViewOptions
+	if listOptions != nil {
+		o = &transaction.ViewOptions{
+			Details: listOptions.Details,
+			Fields: listOptions.Fields,
+		}
+	}
+	data, _, err := t.tx.List(context.Background(), t.findRawSchema(schemaID), transaction.Filter(filter), o, (*pagination.Paginator)(paginator))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/server/resources/resource_management.go
+++ b/server/resources/resource_management.go
@@ -239,7 +239,7 @@ func GetResourcesInTransaction(context middleware.Context, resourceSchema *schem
 		return err
 	}
 
-	var o *transaction.ViewOptions
+	o := &transaction.ViewOptions{Details: true}
 	r, ok := context["http_request"].(*http.Request)
 	if ok {
 		o = listOptionsFromQueryParameter(r.URL.Query())
@@ -480,7 +480,7 @@ func GetSingleResource(context middleware.Context, dataStore db.DB, resourceSche
 //GetSingleResourceInTransaction get resource in single transaction
 func GetSingleResourceInTransaction(context middleware.Context, resourceSchema *schema.Schema, resourceID string, tenantIDs []string, domainIDs []string) (err error) {
 	defer MeasureRequestTime(time.Now(), "get.single.in_tx", resourceSchema.ID)
-	var options *transaction.ViewOptions
+	options := &transaction.ViewOptions{Details: true}
 	r, ok := context["http_request"].(*http.Request)
 	if ok {
 		options = listOptionsFromQueryParameter(r.URL.Query())
@@ -1270,7 +1270,7 @@ func validateAttachmentRelation(
 	extendFilterByTenantAndDomain(relatedSchema, filter, schema.ActionRead, otherCond, auth)
 	otherCond.AddCustomFilters(relatedSchema, filter, auth)
 
-	options := &transaction.ViewOptions{}
+	options := &transaction.ViewOptions{Details: true}
 
 	mainTransaction := mustGetTransaction(context)
 	relatedRes, err := mainTransaction.Fetch(mustGetContext(context), relatedSchema, filter, options)


### PR DESCRIPTION
Disable join by default for extensions.
Please note that this PR _**breaks backward compatibility**_ for extensions which fetch/list resources directly by [transcation interface](https://github.com/cloudwan/gohan/blob/master/extension/goext/transaction.go#L80) and pass `nil` to `listOptions`.
In any other case, compatibility is preserved including API requests (they still make join for any query) and locks (joins are managed explicitly by [lock policy](https://github.com/cloudwan/gohan/blob/master/db/sql/sql.go#L917)