### PR TITLE
Replace "golang.org/x/net/context" imports with "context"

### DIFF
--- a/extension/otto/gohan_sync.go
+++ b/extension/otto/gohan_sync.go
@@ -16,8 +16,9 @@
 package otto
 
 import (
+	"context"
+
 	"github.com/robertkrimen/otto"
-	"golang.org/x/net/context"
 
 	"github.com/cloudwan/gohan/sync"
 )

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,6 @@ require (
 	github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b // indirect
 	go.etcd.io/bbolt v1.3.2 // indirect
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
-	golang.org/x/net v0.0.0-20190603091049-60506f45cf65
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/appengine v1.6.2 // indirect
 	google.golang.org/genproto v0.0.0-20180621235812-80063a038e33 // indirect

--- a/sync/etcdv3/etcd_test.go
+++ b/sync/etcdv3/etcd_test.go
@@ -1,6 +1,7 @@
 package etcdv3
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -8,7 +9,6 @@ import (
 	"github.com/cloudwan/gohan/extension/goext"
 	gohan_sync "github.com/cloudwan/gohan/sync"
 	etcd "github.com/coreos/etcd/clientv3"
-	"golang.org/x/net/context"
 )
 
 var (


### PR DESCRIPTION
Since Go 1.7 `golang.org/x/net/context` is available in standard library. In addition, we already use `context` in most places. 

Kubernetes did similar update almost two years ago ( https://github.com/kubernetes/kubernetes/pull/60563 ) and it did not require any code changes except imports.