### PR TITLE
Fix assertion in OpenAPI v3 test

### DIFF
--- a/cli/openapi3_test.go
+++ b/cli/openapi3_test.go
@@ -56,11 +56,11 @@ var _ = Describe("OpenAPI v3", func() {
 
 	It("Root should contain info section and OpenAPI version", func() {
 		Expect(root.OpenAPI).To(Equal(openApiVersion))
-		Expect(root.Info, WithTransform(transformJSON, Equal(transformJSON(openapi3.Info{
+		Expect(transformJSON(root.Info)).To(Equal(transformJSON(openapi3.Info{
 			Title:       apiTitle,
 			Version:     apiVersion,
 			Description: apiDescription,
-		}))))
+		})))
 	})
 
 	Describe("Properties", func() {


### PR DESCRIPTION
WithTransform() was used incorrectly - it should be inside To(), not Expect().
Due to this, assertion was constructed in such a way that it always passed,
regardless of what the code under test returned.

WithTransform() was not consistent with the rest of the code which called
transformJSON() directly, therefore it was removed.