### PR TITLE
CW-2355: persist pending post migration events in database.

### DIFF
--- a/cli/migrate.go
+++ b/cli/migrate.go
@@ -25,18 +25,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudwan/gohan/db"
-	"github.com/cloudwan/gohan/db/dbutil"
 	"github.com/cloudwan/gohan/db/migration"
 	db_options "github.com/cloudwan/gohan/db/options"
 	db_sql "github.com/cloudwan/gohan/db/sql"
-	"github.com/cloudwan/gohan/extension"
-	"github.com/cloudwan/gohan/extension/goplugin"
-	"github.com/cloudwan/gohan/extension/otto"
 	"github.com/cloudwan/gohan/schema"
-	"github.com/cloudwan/gohan/server"
-	"github.com/cloudwan/gohan/server/middleware"
-	"github.com/cloudwan/gohan/sync"
 	sync_util "github.com/cloudwan/gohan/sync/util"
 	"github.com/cloudwan/gohan/util"
 	"github.com/urfave/cli"
@@ -106,40 +98,6 @@ func selectModifiedSchemas(forcedSchemas string) []string {
 		return strings.Split(forcedSchemas, ",")
 	}
 	return migration.GetModifiedSchemas()
-}
-
-func emitPostMigrateEvent(ctx context_pkg.Context, forcedSchemas string, syncETCDEvent bool, postMigrationEventTimeout time.Duration) {
-	config := util.GetConfig()
-
-	log.Info("Emit post-migrate event")
-
-	modifiedSchemas := selectModifiedSchemas(forcedSchemas)
-
-	if len(modifiedSchemas) == 0 {
-		log.Info("No modified schemas, skipping post-migration event")
-		return
-	}
-
-	log.Debug("Modified schemas: %s", strings.Join(modifiedSchemas, ", "))
-
-	schemaFiles := config.GetStringList("schemas", nil)
-
-	if schemaFiles == nil {
-		log.Fatal("No schema specified in configuration")
-	}
-
-	manager := schema.GetManager()
-	if err := manager.LoadSchemasFromFiles(schemaFiles...); err != nil {
-		log.Fatal(err)
-	}
-
-	if err := publishPostMigrateEvent(ctx, postMigrationEnvName, modifiedSchemas, syncETCDEvent, postMigrationEventTimeout); err != nil {
-		log.Fatal("Publish post-migrate event failed: %s", err)
-	}
-
-	schema.ClearManager()
-
-	log.Info("Published post-migrate event: %s", strings.Join(modifiedSchemas, ", "))
 }
 
 func actionMigrate(subcmd string) func(context *cli.Context) {
@@ -230,121 +188,6 @@ func actionMigrateCreateInitialMigration() func(context *cli.Context) {
 		err := ioutil.WriteFile(path, sqlString.Bytes(), os.ModePerm)
 		if err != nil {
 			fmt.Println(err)
-		}
-	}
-}
-
-func publishPostMigrateEvent(ctx context_pkg.Context, envName string, modifiedSchemas []string, syncETCDEvent bool,
-	eventTimeout time.Duration) error {
-
-	config := util.GetConfig()
-
-	rawDB, err := dbutil.CreateFromConfig(config)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db := server.NewDbSyncWrapper(rawDB)
-
-	sync, err := sync_util.CreateFromConfig(config)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ident, err := middleware.CreateIdentityServiceFromConfig(config)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	envManager := extension.GetManager()
-	manager := schema.GetManager()
-
-	publishPostMigrateEventWithServices(ctx, envName, modifiedSchemas, syncETCDEvent, eventTimeout, db, manager, envManager,
-		sync, ident)
-
-	return nil
-}
-
-func publishPostMigrateEventWithServices(ctx context_pkg.Context, envName string, modifiedSchemas []string, syncETCDEvent bool,
-	eventTimeout time.Duration, db db.DB, manager *schema.Manager, envManager *extension.Manager, sync sync.Sync,
-	ident middleware.IdentityService) {
-
-	deadline := time.Now().Add(eventTimeout)
-
-	for _, s := range manager.Schemas() {
-		if !util.ContainsString(modifiedSchemas, s.ID) {
-			continue
-		}
-
-		pluralURL := s.GetPluralURL()
-
-		if _, ok := envManager.GetEnvironment(s.ID); !ok {
-			now := time.Now()
-			left := deadline.Sub(now)
-			if now.After(deadline) {
-				log.Fatalf("Timeout after '%s' secs while publishing event to schemas", eventTimeout.Seconds())
-			}
-
-			envOtto := otto.NewEnvironment(envName, db, ident, sync)
-			envOtto.SetEventTimeLimit(eventPostMigration, left)
-
-			envGoplugin := goplugin.NewEnvironment(envName, nil, nil)
-			envGoplugin.SetDatabase(db)
-			envGoplugin.SetSync(sync)
-
-			env := extension.NewEnvironment([]extension.Environment{envOtto, envGoplugin})
-
-			log.Info("Loading environment for %s schema with URL: %s", s.ID, pluralURL)
-
-			if err := env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, pluralURL); err != nil {
-				log.Fatal(fmt.Sprintf("[%s] %v", pluralURL, err))
-			}
-
-			envManager.RegisterEnvironment(s.ID, env)
-		}
-
-		env, _ := envManager.GetEnvironment(s.ID)
-
-		eventContext := map[string]interface{}{}
-		eventContext["schema"] = s
-		eventContext["schema_id"] = s.ID
-		eventContext["sync"] = sync
-		eventContext["db"] = db
-		eventContext["identity_service"] = ident
-		eventContext["context"] = ctx
-		eventContext["trace_id"] = util.NewTraceID()
-
-		if err := env.HandleEvent(eventPostMigration, eventContext); err != nil {
-			log.Fatalf("Failed to handle event '%s': %s", eventPostMigration, err)
-		}
-
-		if err := migration.UnmarkSchema(s.ID); err != nil {
-			log.Fatalf("Failed to remove '%s' from pending post migration schemas: %s", s.ID, err)
-		}
-	}
-
-	clearDeadPendingSchemas(modifiedSchemas, manager)
-
-	if syncETCDEvent {
-		if _, err := server.NewSyncWriter(sync, db).Sync(ctx); err != nil {
-			log.Fatalf("Failed to synchronize post-migration events, err: %s", err)
-		}
-	}
-}
-
-func clearDeadPendingSchemas(modifiedSchemas []string, manager *schema.Manager) {
-	for _, schemaID := range modifiedSchemas {
-		_, exists := manager.Schema(schemaID)
-		if exists {
-			continue
-		}
-
-		log.Warning("Found no longer existing schema '%s' in pending post-migration events, removing", schemaID)
-		if err := migration.UnmarkSchema(schemaID); err != nil {
-			log.Fatalf("Failed to remove no longer existing '%s' from pending post migration schemas: %s", schemaID, err)
 		}
 	}
 }

--- a/cli/migrate.go
+++ b/cli/migrate.go
@@ -273,7 +273,6 @@ func publishPostMigrateEventWithServices(ctx context_pkg.Context, envName string
 	ident middleware.IdentityService) {
 
 	deadline := time.Now().Add(eventTimeout)
-	eventName := eventPostMigration
 
 	for _, s := range manager.Schemas() {
 		if !util.ContainsString(modifiedSchemas, s.ID) {
@@ -290,7 +289,7 @@ func publishPostMigrateEventWithServices(ctx context_pkg.Context, envName string
 			}
 
 			envOtto := otto.NewEnvironment(envName, db, ident, sync)
-			envOtto.SetEventTimeLimit(eventName, left)
+			envOtto.SetEventTimeLimit(eventPostMigration, left)
 
 			envGoplugin := goplugin.NewEnvironment(envName, nil, nil)
 			envGoplugin.SetDatabase(db)
@@ -318,8 +317,8 @@ func publishPostMigrateEventWithServices(ctx context_pkg.Context, envName string
 		eventContext["context"] = ctx
 		eventContext["trace_id"] = util.NewTraceID()
 
-		if err := env.HandleEvent(eventName, eventContext); err != nil {
-			log.Fatalf("Failed to handle event '%s': %s", eventName, err)
+		if err := env.HandleEvent(eventPostMigration, eventContext); err != nil {
+			log.Fatalf("Failed to handle event '%s': %s", eventPostMigration, err)
 		}
 
 		if err := migration.UnmarkSchema(s.ID); err != nil {

--- a/cli/post_migration.go
+++ b/cli/post_migration.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2020 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	context_pkg "context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cloudwan/gohan/db"
+	"github.com/cloudwan/gohan/db/dbutil"
+	"github.com/cloudwan/gohan/db/migration"
+	"github.com/cloudwan/gohan/extension"
+	"github.com/cloudwan/gohan/extension/goplugin"
+	"github.com/cloudwan/gohan/extension/otto"
+	"github.com/cloudwan/gohan/schema"
+	"github.com/cloudwan/gohan/server"
+	"github.com/cloudwan/gohan/server/middleware"
+	"github.com/cloudwan/gohan/sync"
+	sync_util "github.com/cloudwan/gohan/sync/util"
+	"github.com/cloudwan/gohan/util"
+)
+
+func emitPostMigrateEvent(ctx context_pkg.Context, forcedSchemas string, syncETCDEvent bool,
+	postMigrationEventTimeout time.Duration) {
+
+	e := &postMigrationEventEmitter{
+		ctx:           ctx,
+		forcedSchemas: forcedSchemas,
+		syncETCDEvent: syncETCDEvent,
+		eventTimeout:  postMigrationEventTimeout,
+	}
+
+	e.emit()
+}
+
+type postMigrationEventEmitter struct {
+	ctx           context_pkg.Context
+	forcedSchemas string
+	syncETCDEvent bool
+	eventTimeout  time.Duration
+}
+
+func (e *postMigrationEventEmitter) emit() {
+	config := util.GetConfig()
+
+	log.Info("Emit post-migrate event")
+
+	modifiedSchemas := selectModifiedSchemas(e.forcedSchemas)
+
+	if len(modifiedSchemas) == 0 {
+		log.Info("No modified schemas, skipping post-migration event")
+		return
+	}
+
+	log.Debug("Modified schemas: %s", strings.Join(modifiedSchemas, ", "))
+
+	schemaFiles := config.GetStringList("schemas", nil)
+
+	if schemaFiles == nil {
+		log.Fatal("No schema specified in configuration")
+	}
+
+	manager := schema.GetManager()
+	if err := manager.LoadSchemasFromFiles(schemaFiles...); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := e.publishPostMigrateEvent(postMigrationEnvName, modifiedSchemas); err != nil {
+		log.Fatal("Publish post-migrate event failed: %s", err)
+	}
+
+	schema.ClearManager()
+
+	log.Info("Published post-migrate event: %s", strings.Join(modifiedSchemas, ", "))
+}
+
+func (e *postMigrationEventEmitter) publishPostMigrateEvent(envName string, modifiedSchemas []string) error {
+	config := util.GetConfig()
+
+	rawDB, err := dbutil.CreateFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db := server.NewDbSyncWrapper(rawDB)
+
+	sync, err := sync_util.CreateFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ident, err := middleware.CreateIdentityServiceFromConfig(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	envManager := extension.GetManager()
+	manager := schema.GetManager()
+
+	e.publishPostMigrateEventWithServices(envName, modifiedSchemas, db, manager, envManager, sync, ident)
+
+	return nil
+}
+
+func (e *postMigrationEventEmitter) publishPostMigrateEventWithServices(envName string, modifiedSchemas []string, db db.DB,
+	manager *schema.Manager, envManager *extension.Manager, sync sync.Sync, ident middleware.IdentityService) {
+
+	deadline := time.Now().Add(e.eventTimeout)
+
+	for _, s := range manager.Schemas() {
+		if !util.ContainsString(modifiedSchemas, s.ID) {
+			continue
+		}
+
+		pluralURL := s.GetPluralURL()
+
+		if _, ok := envManager.GetEnvironment(s.ID); !ok {
+			now := time.Now()
+			left := deadline.Sub(now)
+			if now.After(deadline) {
+				log.Fatalf("Timeout after '%s' secs while publishing event to schemas", e.eventTimeout.Seconds())
+			}
+
+			envOtto := otto.NewEnvironment(envName, db, ident, sync)
+			envOtto.SetEventTimeLimit(eventPostMigration, left)
+
+			envGoplugin := goplugin.NewEnvironment(envName, nil, nil)
+			envGoplugin.SetDatabase(db)
+			envGoplugin.SetSync(sync)
+
+			env := extension.NewEnvironment([]extension.Environment{envOtto, envGoplugin})
+
+			log.Info("Loading environment for %s schema with URL: %s", s.ID, pluralURL)
+
+			if err := env.LoadExtensionsForPath(manager.Extensions, manager.TimeLimit, manager.TimeLimits, pluralURL); err != nil {
+				log.Fatal(fmt.Sprintf("[%s] %v", pluralURL, err))
+			}
+
+			envManager.RegisterEnvironment(s.ID, env)
+		}
+
+		env, _ := envManager.GetEnvironment(s.ID)
+
+		eventContext := map[string]interface{}{}
+		eventContext["schema"] = s
+		eventContext["schema_id"] = s.ID
+		eventContext["sync"] = sync
+		eventContext["db"] = db
+		eventContext["identity_service"] = ident
+		eventContext["context"] = e.ctx
+		eventContext["trace_id"] = util.NewTraceID()
+
+		if err := env.HandleEvent(eventPostMigration, eventContext); err != nil {
+			log.Fatalf("Failed to handle event '%s': %s", eventPostMigration, err)
+		}
+
+		if err := migration.UnmarkSchema(s.ID); err != nil {
+			log.Fatalf("Failed to remove '%s' from pending post migration schemas: %s", s.ID, err)
+		}
+	}
+
+	e.clearDeadPendingSchemas(modifiedSchemas, manager)
+
+	if e.syncETCDEvent {
+		if _, err := server.NewSyncWriter(sync, db).Sync(e.ctx); err != nil {
+			log.Fatalf("Failed to synchronize post-migration events, err: %s", err)
+		}
+	}
+}
+
+func (e *postMigrationEventEmitter) clearDeadPendingSchemas(modifiedSchemas []string, manager *schema.Manager) {
+	for _, schemaID := range modifiedSchemas {
+		_, exists := manager.Schema(schemaID)
+		if exists {
+			continue
+		}
+
+		log.Warning("Found no longer existing schema '%s' in pending post-migration events, removing", schemaID)
+		if err := migration.UnmarkSchema(schemaID); err != nil {
+			log.Fatalf("Failed to remove no longer existing '%s' from pending post migration schemas: %s", schemaID, err)
+		}
+	}
+}

--- a/db/migration/migration_suite_test.go
+++ b/db/migration/migration_suite_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSchema(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Migration Suite")
+}

--- a/db/migration/schema_set.go
+++ b/db/migration/schema_set.go
@@ -1,0 +1,219 @@
+// Copyright (C) 2020 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"database/sql"
+	"errors"
+)
+
+type stringSet map[string]bool
+
+type schemaSetBackend interface {
+	loadSchemaIDs() (stringSet, error)
+	persistSchemaID(schemaID string, tx *sql.Tx) error
+	deleteSchemaID(schemaID string) error
+}
+
+var errNilBackend = errors.New("schemaSetBackend is nil")
+
+type schemaSet struct {
+	schemas stringSet
+	backend schemaSetBackend
+}
+
+func newSchemaSet() *schemaSet {
+	return &schemaSet{
+		schemas: stringSet{},
+		backend: nil, // there is a global schemaSet instance, backend must be lazily initialized
+	}
+}
+
+func (s *schemaSet) init(backend schemaSetBackend) (err error) {
+	log.Notice("post-migration: initializing schema ID set")
+
+	if backend == nil {
+		return errNilBackend
+	}
+
+	s.backend = backend
+
+	schemas, err := backend.loadSchemaIDs()
+	if err != nil {
+		return err
+	}
+
+	s.schemas = schemas
+
+	return nil
+}
+
+func (s *schemaSet) markSchemaID(schemaID string, tx *sql.Tx) (err error) {
+	log.Info("post-migration: marking schema '%s'", schemaID)
+
+	if s.backend == nil {
+		return errNilBackend
+	}
+
+	err = s.backend.persistSchemaID(schemaID, tx)
+	if err != nil {
+		return err
+	}
+
+	s.schemas[schemaID] = true
+	return nil
+}
+
+func (s *schemaSet) getSchemaIDs() []string {
+	schemas := make([]string, 0, len(s.schemas))
+	for schema := range s.schemas {
+		schemas = append(schemas, schema)
+	}
+	return schemas
+}
+
+func (s *schemaSet) removeSchemaID(schemaID string) error {
+	log.Info("post-migration: removing schema '%s'", schemaID)
+
+	if s.backend == nil {
+		return errNilBackend
+	}
+
+	err := s.backend.deleteSchemaID(schemaID)
+	if err != nil {
+		return err
+	}
+
+	delete(s.schemas, schemaID)
+	return nil
+}
+
+type postMigrationEventsBackend struct {
+	db *sql.DB
+}
+
+var _ schemaSetBackend = &postMigrationEventsBackend{}
+
+func newSchemaSetDbBackend(db *sql.DB) *postMigrationEventsBackend {
+	return &postMigrationEventsBackend{db: db}
+}
+
+const schemaSetDbTable = "post_migration_events"
+
+func (b *postMigrationEventsBackend) loadSchemaIDs() (stringSet, error) {
+	log.Debug("post-migration: preloading pending schema IDs")
+
+	tx, err := b.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	schemas, err := b.readSchemaIDsInTx(tx)
+	if err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, err
+	}
+
+	return schemas, nil
+}
+
+func (b *postMigrationEventsBackend) readSchemaIDsInTx(tx *sql.Tx) (stringSet, error) {
+	if err := b.ensureTableExists(tx); err != nil {
+		return nil, err
+	}
+
+	const query = "SELECT `schema_id` FROM `" + schemaSetDbTable + "`"
+	rows, err := tx.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	schemas := make(stringSet)
+
+	for rows.Next() {
+		var schema string
+		if err := rows.Scan(&schema); err != nil {
+			return nil, err
+		}
+
+		schemas[schema] = true
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	log.Debug("post-migration: read %d pending schema IDs", len(schemas))
+	return schemas, nil
+}
+
+func (b *postMigrationEventsBackend) ensureTableExists(tx *sql.Tx) error {
+	log.Debug("post-migration: making sure table `%s` exists", schemaSetDbTable)
+
+	const stmt = "CREATE TABLE IF NOT EXISTS `" + schemaSetDbTable + "` (`schema_id` TEXT NOT NULL)"
+	_, err := tx.Exec(stmt)
+
+	return err
+}
+
+func (b *postMigrationEventsBackend) persistSchemaID(schemaID string, tx *sql.Tx) error {
+	log.Debug("post-migration: persiting schemaID '%s' into `%s`", schemaID, schemaSetDbTable)
+	const stmtTemplate = "INSERT INTO `" + schemaSetDbTable + "` (`schema_id`) VALUES (?)"
+
+	return b.execStmt(tx, stmtTemplate, schemaID)
+}
+
+func (b *postMigrationEventsBackend) deleteSchemaID(schemaID string) error {
+	log.Debug("post-migration: deleting schemaID '%s' from schema set", schemaID)
+	tx, err := b.db.Begin()
+
+	if err != nil {
+		return err
+	}
+
+	const stmtTemplate = "DELETE FROM `" + schemaSetDbTable + "` WHERE `schema_id` = ?"
+	err = b.execStmt(tx, stmtTemplate, schemaID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *postMigrationEventsBackend) execStmt(tx *sql.Tx, stmtTemplate, value string) error {
+	log.Debug("post-migration: executing '%s' with '%s'", stmtTemplate, value)
+
+	stmt, err := tx.Prepare(stmtTemplate)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(value)
+	return err
+}

--- a/db/migration/schema_set_test.go
+++ b/db/migration/schema_set_test.go
@@ -1,0 +1,179 @@
+// Copyright (C) 2020 NTT Innovation Institute, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"database/sql"
+	"errors"
+	"sort"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type fakeSchemaSetBackend struct {
+	initialIDs    []string
+	persistedIDs  []string
+	deletedIDs    []string
+	failLoad      bool
+	failOperation bool
+}
+
+func (b *fakeSchemaSetBackend) loadSchemaIDs() (stringSet, error) {
+	if b.failLoad {
+		return nil, errors.New("failure test")
+	}
+
+	result := make(stringSet, len(b.initialIDs))
+	for _, id := range b.initialIDs {
+		result[id] = true
+	}
+
+	return result, nil
+}
+
+func (b *fakeSchemaSetBackend) persistSchemaID(schemaID string, tx *sql.Tx) error {
+	if b.failOperation {
+		return errors.New("failure test")
+	}
+
+	b.persistedIDs = append(b.persistedIDs, schemaID)
+	return nil
+}
+
+func (b *fakeSchemaSetBackend) deleteSchemaID(schemaID string) error {
+	if b.failOperation {
+		return errors.New("failure test")
+	}
+
+	b.deletedIDs = append(b.deletedIDs, schemaID)
+	return nil
+}
+
+var _ schemaSetBackend = &fakeSchemaSetBackend{}
+
+var _ = Describe("Schema Set", func() {
+	var (
+		set *schemaSet
+	)
+
+	BeforeEach(func() {
+		set = newSchemaSet()
+	})
+
+	expectEmptySet := func() {
+		Expect(set.getSchemaIDs()).To(BeEmpty())
+	}
+
+	It("Should have no schemas after construction", func() {
+		expectEmptySet()
+	})
+
+	It("Should fail initialization with nil backend", func() {
+		Expect(set.init(nil)).NotTo(Succeed())
+		expectEmptySet()
+	})
+
+	It("Should fail initialization when backend fails", func() {
+		Expect(set.init(&fakeSchemaSetBackend{failLoad: true})).NotTo(Succeed())
+		expectEmptySet()
+	})
+
+	expectSchemaIDs := func(expectedIDs []string) {
+		actualIDs := set.getSchemaIDs()
+
+		sort.Strings(actualIDs)
+		sort.Strings(expectedIDs)
+
+		Expect(actualIDs).To(Equal(expectedIDs))
+	}
+
+	It("Should load schemaIDs from backend", func() {
+		expectedIDs := []string{"a", "b", "c"}
+
+		Expect(set.init(&fakeSchemaSetBackend{initialIDs: expectedIDs})).To(Succeed())
+
+		expectSchemaIDs(expectedIDs)
+	})
+
+	It("Should persist marked schemaIDs", func() {
+		backend := &fakeSchemaSetBackend{initialIDs: []string{"a", "b"}}
+		Expect(set.init(backend)).To(Succeed())
+
+		Expect(set.markSchemaID("x", nil)).To(Succeed())
+		Expect(set.markSchemaID("y", nil)).To(Succeed())
+
+		expectSchemaIDs([]string{"a", "b", "x", "y"})
+		Expect(backend.persistedIDs).To(Equal([]string{"x", "y"}))
+	})
+
+	It("Should not mark schemaID if backend nil", func() {
+		Expect(set.markSchemaID("x", nil)).NotTo(Succeed())
+		expectEmptySet()
+	})
+
+	It("Should not mark schemaID if backend fails", func() {
+		backend := &fakeSchemaSetBackend{}
+		Expect(set.init(backend)).To(Succeed())
+		Expect(set.markSchemaID("x", nil)).To(Succeed())
+
+		backend.failOperation = true
+		Expect(set.markSchemaID("y", nil)).NotTo(Succeed())
+
+		expectSchemaIDs([]string{"x"})
+	})
+
+	Context("Given initial schema IDs", func() {
+		const (
+			aID = "schemaA"
+			bID = "schemaB"
+		)
+
+		var (
+			backend *fakeSchemaSetBackend
+		)
+
+		BeforeEach(func() {
+			backend = &fakeSchemaSetBackend{initialIDs: []string{aID, bID}}
+			Expect(set.init(backend)).To(Succeed())
+		})
+
+		It("Should persist removed schemaIDs", func() {
+			Expect(set.removeSchemaID(aID)).To(Succeed())
+
+			expectSchemaIDs([]string{bID})
+			Expect(backend.deletedIDs).To(Equal([]string{aID}))
+		})
+
+		It("Should ignore removal of not stored schemaID", func() {
+			Expect(set.removeSchemaID("no such id")).To(Succeed())
+
+			expectSchemaIDs([]string{aID, bID})
+		})
+
+		It("Should not remove schemaID if backend fails", func() {
+			backend.failOperation = true
+
+			Expect(set.removeSchemaID(bID)).NotTo(Succeed())
+
+			expectSchemaIDs([]string{aID, bID})
+		})
+	})
+
+	It("Should not remove schemaID if backend nil", func() {
+		Expect(set.removeSchemaID("id")).NotTo(Succeed())
+	})
+})

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,11 @@ Schemas might also have any of the following optional properties.
 - metadata  -- application specific schema metadata (object)
 - type      -- can be an abstract or empty string (see more in schema inheritance)
 - extends   -- list of base schemas
-- order_properties_before -- to order properties before properties of extended schemas. 
+- order_properties_before -- to order properties before properties of extended schemas.
+
+## Schema ID
+
+Schema ID (`id:`) must be unique and cannot be equal to a reserved gohan identifier including but not limited to "goose_db_version" and "post_migration_event(s)".
 
 ## Schema Inheritance
 


### PR DESCRIPTION
We allow migrations to mark schema IDs as modified to later trigger
the "post-migration" event for them. We used to store that set in
memory only. This potentially led to lost post-migration events when
e.g. etcd was unavailable at the time of applying migrations or one of
the event handlers failed. Another run of "migrate up" did not mark
the same schemas again, because db migrations were already applied and
thus not executed. It was also easy to miss the fact that
post-migration events were not triggered.

This commit introduces an additional db store for the modified schema
set. This way, if gohan can't handle all post-migration events,
remaining ones will be loaded from the database on next try. Pending
post-migration events also block running `gohan server` in `no_init`
mode, this mirrors the behavior of pending migrations. It makes it
also impossible to unintentionally ignore.

Newly introduced behavior is compatible with forced post-migration
events. If a forced schema happens to have a pending post-migration
event, it will be treated as completed, provided the event handler
succeded. If one forces 2 out of 3 pending schemas, the remaining one
will still block execution of `gohan server`.