### PR TITLE
Validate Keystone V3 roles for admin authorization.

### DIFF
--- a/cloud/keystone_test_utils.go
+++ b/cloud/keystone_test_utils.go
@@ -50,10 +50,7 @@ func getV3TokensScopedToTenantResponse() interface{} {
 				"name": "admin",
 			},
 			"roles": []interface{}{
-				map[string]interface{}{
-					"id":   "51cc68287d524c759f47c811e6463340",
-					"name": "member",
-				},
+				getMemberRole(),
 			},
 			"catalog": []interface{}{},
 			"project": map[string]interface{}{
@@ -85,10 +82,7 @@ func getV3TokensScopedToDomainResponse() interface{} {
 				"name": "admin",
 			},
 			"roles": []interface{}{
-				map[string]interface{}{
-					"id":   "51cc68287d524c759f47c811e6463340",
-					"name": "member",
-				},
+				getMemberRole(),
 			},
 			"catalog": []interface{}{},
 			"domain": map[string]interface{}{
@@ -100,12 +94,7 @@ func getV3TokensScopedToDomainResponse() interface{} {
 }
 
 func getV3TokensAdminResponse() interface{} {
-	return getV3TokensAdminResponseWithRoles([]interface{}{
-		map[string]interface{}{
-			"id":   "7f0ea059b6d84029b60c18169d3c1d9a",
-			"name": "admin",
-		},
-	})
+	return getV3TokensAdminResponseWithRoles([]interface{}{getAdminRole()})
 }
 
 func getV3TokensAdminResponseWithRoles(roles []interface{}) interface{} {
@@ -136,6 +125,20 @@ func getV3TokensAdminResponseWithRoles(roles []interface{}) interface{} {
 			},
 			"is_admin_project": true,
 		},
+	}
+}
+
+func getMemberRole() map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "51cc68287d524c759f47c811e6463340",
+		"name": "Member",
+	}
+}
+
+func getAdminRole() map[string]interface{} {
+	return map[string]interface{}{
+		"id":   "7f0ea059b6d84029b60c18169d3c1d9a",
+		"name": "admin",
 	}
 }
 

--- a/cloud/keystone_test_utils.go
+++ b/cloud/keystone_test_utils.go
@@ -100,6 +100,15 @@ func getV3TokensScopedToDomainResponse() interface{} {
 }
 
 func getV3TokensAdminResponse() interface{} {
+	return getV3TokensAdminResponseWithRoles([]interface{}{
+		map[string]interface{}{
+			"id":   "7f0ea059b6d84029b60c18169d3c1d9a",
+			"name": "admin",
+		},
+	})
+}
+
+func getV3TokensAdminResponseWithRoles(roles []interface{}) interface{} {
 	return map[string]interface{}{
 		"token": map[string]interface{}{
 			"expires_at": "2013-02-27T18:30:59.999999Z",
@@ -115,16 +124,7 @@ func getV3TokensAdminResponse() interface{} {
 				"id":   "1234",
 				"name": "admin",
 			},
-			"roles": []interface{}{
-				map[string]interface{}{
-					"id":   "51cc68287d524c759f47c811e6463340",
-					"name": "member",
-				},
-				map[string]interface{}{
-					"id":   "7f0ea059b6d84029b60c18169d3c1d9a",
-					"name": "admin",
-				},
-			},
+			"roles":   roles,
 			"catalog": []interface{}{},
 			"project": map[string]interface{}{
 				"domain": map[string]interface{}{

--- a/schema/policy.go
+++ b/schema/policy.go
@@ -52,7 +52,7 @@ const (
 
 	onlyOneOfTenantIDTenantNameError = "Only one of [tenant_id, tenant_name] should be specified"
 
-	adminRole = "admin"
+	AdminRole = "admin"
 )
 
 // AllActions are all possible actions
@@ -234,7 +234,7 @@ func (ab *AuthorizationBuilder) BuildScopedToTenant() Authorization {
 	if ab.authViaKeystoneV2 {
 		// When using Keystone V2, user is an admin if they have an admin role in the current project
 		for _, role := range ab.roles {
-			if role.Name == adminRole {
+			if role.Name == AdminRole {
 				return ab.BuildAdmin()
 			}
 		}


### PR DESCRIPTION
Our intention is for admin auth to be allowed to do anything. That's
accomplished through the built-in `admin_statement` policy.
Unfortunately if we assign multiple roles to it, it's possible that a
policy with "effect: deny" for one of those roles will block some
operation, possibly making it impossible to use admin token to revert
some changes. This commit rejects such Keystone V3 tokens, effectively
forcing a desired configuration of Keystone users and role assignments.