### PR TITLE
CW-1782: fully recursively populate default values.

### DIFF
--- a/schema/resource.go
+++ b/schema/resource.go
@@ -154,7 +154,7 @@ func fillObjectDefaults(objectProperty Property, resourceMap, defaultValueMaskMa
 				if resourceFilled {
 					fillObjectDefaults(innerProperty, resourceFilledProperty.(map[string]interface{}), innerPropertyMaskMap)
 				} else {
-					if innerPropertyMaskMap != nil && innerProperty.Default != nil {
+					if innerPropertyMaskMap != nil && innerProperty.DefaultMask != nil {
 						resourceMap[innerProperty.ID] = innerPropertyMaskMap
 					}
 				}

--- a/schema/resource_test.go
+++ b/schema/resource_test.go
@@ -133,6 +133,10 @@ var _ = Describe("Resources", func() {
 		networkRed := NewResource(networkSchema, networkRedObj)
 		Expect(networkRed.PopulateDefaults()).To(Succeed())
 		expectedConfig := map[string]interface{}{
+			"default_vlan": map[string]interface{}{
+				"name":    "default_vlan",
+				"vlan_id": float64(1),
+			},
 			"empty_vlan": map[string]interface{}{},
 			"vpn_vlan": map[string]interface{}{
 				"name": "vpn_vlan",
@@ -162,7 +166,7 @@ var _ = Describe("Resources", func() {
 		Expect(actualProvidorNetworks).To(Equal(expectedProvidorNetworks))
 	})
 
-	It("override property which has default object", func() {
+	It("override property which has default subproperties", func() {
 		networkSchema, exists := manager.Schema("network")
 		Expect(exists).To(BeTrue())
 		networkRedObj := map[string]interface{}{
@@ -180,6 +184,10 @@ var _ = Describe("Resources", func() {
 		networkRed := NewResource(networkSchema, networkRedObj)
 		Expect(networkRed.PopulateDefaults()).To(Succeed())
 		expectedConfig := map[string]interface{}{
+			"default_vlan": map[string]interface{}{
+				"name":    "default_vlan",
+				"vlan_id": float64(1),
+			},
 			"empty_vlan": map[string]interface{}{},
 			"vpn_vlan": map[string]interface{}{
 				"name": "my_vpn_vlan",


### PR DESCRIPTION
Middle level objects do not always have a default value but their
children might. Use DefaultMask (as it's fully computed) instead of
only Default in order to handle such cases.