### PR TITLE
[CW-3955] Allow 31-Bit Prefixes IPv4 Point-to-Point Links

### DIFF
--- a/schema/formats.go
+++ b/schema/formats.go
@@ -118,18 +118,27 @@ func maskIsValid(mask string) bool {
 	return true
 }
 
+const (
+	pointToPointPrefixSize = 31 // https://tools.ietf.org/rfc/rfc3021.txt
+)
+
 func (f ipv4AddressWithCidrFormatChecker) IsFormat(input string) bool {
 	hostIP, netIP, mask, cidrErr := extractHostAndNet(input)
 	if cidrErr != nil {
 		return false
 	}
 
-	if isBroadcast(hostIP, mask) {
+	inputIp := extractIpFromCidrFormattedString(input)
+	if !matchYangIPv4AddressPattern(inputIp) {
 		return false
 	}
 
-	inputIp := extractIpFromCidrFormattedString(input)
-	if !matchYangIPv4AddressPattern(inputIp) {
+	prefixSize, _ := mask.Size()
+	if prefixSize == pointToPointPrefixSize {
+		return true
+	}
+
+	if isBroadcast(hostIP, mask) {
 		return false
 	}
 	return !hostIP.Equal(netIP)

--- a/schema/formats_test.go
+++ b/schema/formats_test.go
@@ -100,7 +100,6 @@ var _ = Describe("format checkers", func() {
 			Entry("IPv4 with 1 in last octet", "127.0.0.1"),
 			Entry("IPv4 with 10 in last octet", "127.0.0.10"),
 			Entry("IPv4 with 100 in last octet", "127.0.0.100"),
-
 		)
 
 		DescribeTable("should fail",
@@ -221,6 +220,8 @@ var _ = Describe("format checkers", func() {
 			},
 			Entry("cidr with '1' host bits present", "192.168.0.2/24"),
 			Entry("cidr which is not a broadcast", "192.168.255.2/16"),
+			Entry("broadcast address with /31 mask", "10.0.0.3/31"),
+			Entry("network address with /31 mask", "10.0.0.2/31"),
 		)
 
 		DescribeTable("should fail",


### PR DESCRIPTION
See https://tools.ietf.org/rfc/rfc3021.txt for details.
Change validation rule of ipv4AddressWithCidrFormatChecker.